### PR TITLE
Fix FAQ workshop duration

### DIFF
--- a/src/components/MagicWebinar11/index.tsx
+++ b/src/components/MagicWebinar11/index.tsx
@@ -27,7 +27,7 @@ const MagicWebinar11 = ({ version = 1 }: { version?: number }): JSX.Element => {
     },
     {
       question: "Jak długo będą trwały warsztaty?",
-      answer: "Około 60 minut.",
+      answer: "Około 90 minut.",
     },
     {
       question: "Czy warsztat jest odpowiedni dla początkujących?",


### PR DESCRIPTION
## Summary
- update MagicWebinar11 FAQ to specify the workshop lasts 90 minutes instead of 60

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Write tests! -> https://gatsby.dev/unit-testing)*