### PR TITLE
Fix workshop FAQ duration

### DIFF
--- a/src/components/MagicWebinar11/index.tsx
+++ b/src/components/MagicWebinar11/index.tsx
@@ -27,7 +27,7 @@ const MagicWebinar11 = ({ version = 1 }: { version?: number }): JSX.Element => {
     },
     {
       question: "Jak długo będą trwały warsztaty?",
-      answer: "Około 60 minut.",
+      answer: "Około 90 minut.",
     },
     {
       question: "Czy warsztat jest odpowiedni dla początkujących?",


### PR DESCRIPTION
## Summary
- adjust workshop FAQ duration from 60 to 90 minutes

## Testing
- `npm test` *(fails: Write tests! -> https://gatsby.dev/unit-testing)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*