### PR TITLE
Update README quick start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,31 +14,28 @@ _Have another more specific idea? You may want to check out our vibrant collecti
 
 ## 🚀 Quick start
 
-1.  **Create a Gatsby site.**
+1. **Clone this repository.**
 
-    Use the Gatsby CLI to create a new site, specifying the default starter.
+   ```shell
+   git clone <repository-url>
+   cd Ada
+   ```
 
-    ```shell
-    # create a new Gatsby site using the default starter
-    gatsby new my-default-starter https://github.com/gatsbyjs/gatsby-starter-default
-    ```
+2. **Install dependencies.**
 
-1.  **Start developing.**
+   ```shell
+   yarn install
+   ```
 
-    Navigate into your new site’s directory and start it up.
+3. **Start the development server.**
 
-    ```shell
-    cd my-default-starter/
-    gatsby develop
-    ```
+   ```shell
+   yarn develop
+   ```
 
-1.  **Open the source code and start editing!**
+   Your site is now running at `http://localhost:8000`.
 
-    Your site is now running at `http://localhost:8000`!
-
-    _Note: You'll also see a second link: _`http://localhost:8000/___graphql`_. This is a tool you can use to experiment with querying your data. Learn more about using this tool in the [Gatsby tutorial](https://www.gatsbyjs.org/tutorial/part-five/#introducing-graphiql)._
-
-    Open the `my-default-starter` directory in your code editor of choice and edit `src/pages/index.js`. Save your changes and the browser will update in real time!
+   You can also visit `http://localhost:8000/___graphql` to explore the GraphQL API.
 
 ## 🧐 What's inside?
 


### PR DESCRIPTION
## Summary
- update Quick start section with instructions for cloning and running locally
- remove default starter instructions

## Testing
- `none`

------
https://chatgpt.com/codex/tasks/task_e_68527e08809c832e847eb1db2c0921a0