### PR TITLE
Update text formatting on webpage

### DIFF
--- a/src/components/MasterclassAgenda/index.tsx
+++ b/src/components/MasterclassAgenda/index.tsx
@@ -473,10 +473,10 @@ const MasterclassAgenda = ({
                 Bonus: Ustaw reklamę z automatyzacją! (tylko przy zakupie do
                 15.07)
               </p>
-              <p className="text-center font-bold text-adaBase pt-4">
+              <p className="text-center font-bold text-adaBase pt-4 bg-ada-white border border-ada-black px-6 py-4 inline-block">
                 Cena:{" "}
-                <span className="text-adaSubtitle">497 zł</span>. Od 16 lipca:
-                699 zł
+                <span className="text-[1.6875rem] font-extrabold">497 zł</span>. Od 16 lipca:{" "}
+                <span className="line-through">699 zł</span>
               </p>
               <div className="flex justify-center">
                 <BuyChillButton />


### PR DESCRIPTION
Add white frame, increase font size for 497 zł, and strike through 699 zł for the price text on the Adsy&chill 2025 page.

---

[Slack Thread](https://getboldworkspace.slack.com/archives/C07EP85GSV8/p1752230773619219?thread_ts=1752230773.619219&cid=C07EP85GSV8)