### PR TITLE
Update quiz form text with email prompt

### DIFF
--- a/src/components/Quiz/QuizTitle.tsx
+++ b/src/components/Quiz/QuizTitle.tsx
@@ -33,6 +33,10 @@ const QuizTitle = (): JSX.Element => {
           </span>
         </div>
 
+        <p className="font-montserrat text-base md:text-lg text-ada-magicPurple max-w-3xl mx-auto mb-8">
+          Podaj swojego maila, aby otrzymać wyniki i sprawdzić nie tylko swoją adsową osobowość, ale też Twoje wyzwania i supermoce w prowadzeniu reklam. No i… co możesz z tym zrobić! 🔮
+        </p>
+
         <div className="flex justify-center space-x-4 mb-8">
           <div className="bg-ada-magicGreen rounded-full px-6 py-2">
             <span className="text-ada-magicPurple font-bold">12 pytań</span>


### PR DESCRIPTION
Add explanatory text under the quiz title to provide context and encourage email submission for quiz results.

---
[Slack Thread](https://getboldworkspace.slack.com/archives/CKVBMQHJ5/p1755008250591659?thread_ts=1755008250.591659&cid=CKVBMQHJ5)

<a href="https://cursor.com/background-agent?bcId=bc-232223f2-26b5-4fbc-add9-8adb2da0368b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-232223f2-26b5-4fbc-add9-8adb2da0368b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

