### PR TITLE
Fix leftover May issue

### DIFF
--- a/src/components/MagicWebinar11/index.tsx
+++ b/src/components/MagicWebinar11/index.tsx
@@ -20,7 +20,7 @@ const MagicWebinar11 = () => {
     },
     {
       question: "Naprawdę 0 zł?",
-      answer: "Tak. Wersja płatna po 28 maja jest opcjonalna.",
+      answer: "Tak. Wersja płatna jest opcjonalna.",
     },
     {
       question: "Jak długo będą trwały warsztaty?",

--- a/src/components/MagicWebinar11/index.tsx
+++ b/src/components/MagicWebinar11/index.tsx
@@ -20,7 +20,7 @@ const MagicWebinar11 = () => {
     },
     {
       question: "Naprawdę 0 zł?",
-      answer: "Tak. Wersja płatna jest opcjonalna.",
+      answer: "Tak. Wersja płatna po 17 września jest opcjonalna.",
     },
     {
       question: "Jak długo będą trwały warsztaty?",


### PR DESCRIPTION
Remove outdated 'po 28 maja' date reference from FAQ answer.

---
[Slack Thread](https://getboldworkspace.slack.com/archives/CKVBMQHJ5/p1756365032162209?thread_ts=1756365032.162209&cid=CKVBMQHJ5)

<a href="https://cursor.com/background-agent?bcId=bc-d747667f-dbad-4e87-a1fd-630cc8f982e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d747667f-dbad-4e87-a1fd-630cc8f982e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

