### PR TITLE
Zaktualizuj stronę magic nagranie

### DIFF
--- a/src/components/MagicSaleBanner/index.tsx
+++ b/src/components/MagicSaleBanner/index.tsx
@@ -123,6 +123,13 @@ const MagicSaleBanner = ({ version }: { version: number }) => {
           </div>
         </Section>
       )}
+      {version == 6 && (
+        <Section padding="py-8 px-2 md:px-12 text-ada flex flex-col items-center text-center">
+          <h1 className="text-adaTitle2 font-bold text-ada-magicOrange2">
+            Obejrzyj nagranie z masterclassu!
+          </h1>
+        </Section>
+      )}
     </>
   )
 }

--- a/src/components/MagicVideo/index.tsx
+++ b/src/components/MagicVideo/index.tsx
@@ -1,13 +1,26 @@
 import React from "react"
 import Section from "../shared/Section"
 
-const MagicVideo = () => {
+const MagicVideo = ({ version }: { version?: number }) => {
+  // Default video (original)
+  const defaultVideoSrc = "https://player.vimeo.com/video/1117395484?badge=0&autopause=0&player_id=0&app_id=58479"
+  const defaultTitle = "Twoje zaproszenie do MAGIC"
+  
+  // Version 2 video (for magic-nagranie page)
+  const version2VideoSrc = "https://player.vimeo.com/video/1117718298?badge=0&autopause=0&player_id=0&app_id=58479"
+  const version2Title = "Nagranie_ Jesienny re-start"
+  
+  const videoSrc = version === 2 ? version2VideoSrc : defaultVideoSrc
+  const videoTitle = version === 2 ? version2Title : defaultTitle
+
   return (
     <Section bgColor="bg-transparent">
       <div className="max-w-4xl mx-auto">
         <div style={{ padding: "56.25% 0 0 0", position: "relative" }}>
           <iframe
-            src="https://player.vimeo.com/video/1117395484?badge=0&autopause=0&player_id=0&app_id=58479"
+            src={videoSrc}
+            width="1920"
+            height="1080"
             frameBorder="0"
             allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share"
             referrerPolicy="strict-origin-when-cross-origin"
@@ -18,7 +31,7 @@ const MagicVideo = () => {
               width: "100%",
               height: "100%",
             }}
-            title="Twoje zaproszenie do MAGIC"
+            title={videoTitle}
           />
         </div>
       </div>

--- a/src/pages/magic-nagranie.tsx
+++ b/src/pages/magic-nagranie.tsx
@@ -3,83 +3,62 @@ import MaxWithBgColorContainer from "components/Layout/MaxWithBgColorContainer"
 import MagicBanner1 from "components/MagicBanner"
 import MagicBanner2 from "components/MagicBanner2"
 import MagicBioBanner from "components/MagicBioBanner"
+import MagicCommunityOpinions from "components/MagicCommunityOpinions"
 import MagicDateBanner from "components/MagicDateBanner"
-import MagicLastSection from "components/MagicLastSection"
+import MagicFinalCTA from "components/MagicFinalCTA"
+import MagicSaleBanner from "components/MagicSaleBanner"
+import MagicVideo from "components/MagicVideo"
 import MagicWhy from "components/MagicWhy"
 import MasterclassFAQ from "components/MasterclassFAQ"
-import ReferencesMentoring from "components/ReferencesMentoring"
 import SEO from "components/seo"
-import { Button } from "helpers/Button"
 import React from "react"
 
 const MagicNagraniePage = () => {
   return (
     <Layout showHeaderAndFooter={false}>
-      <MaxWithBgColorContainer bgColor="bg-ada-newPurple">
-        <div className="flex flex-col items-center text-center text-white py-16">
-          <h1 className="text-adaSubtitle md:text-adaTitle font-bold mb-8 px-4">
-            Nagranie z warsztatu nie jest już dostępne.
-          </h1>
-          <p className="mb-8 text-lg md:text-xl px-4">
-            Nadal możesz dołączyć do <span className="font-bold">MAGIC</span>!
-          </p>
-          <Button
-            type="button"
-            text={
-              <span className="font-bold text-ada-pink7 uppercase">
-                Dołącz do MAGIC
-              </span>
-            }
-            url="/magic"
-            textSize="text-sm md:text-base"
-            btnStyle="uppercase bg-ada-pink2 text-ada-black font-semibold tracking-wide h-[48px] md:h-[60px] px-6 shadow-xl hover:opacity-90 rounded-full min-w-[130px]"
-          />
-        </div>
-      </MaxWithBgColorContainer>
-      <MaxWithBgColorContainer>
-        <MagicBanner1 version={3} />
-      </MaxWithBgColorContainer>
-      <MaxWithBgColorContainer bgColor="bg-ada-pink7">
-        <MagicWhy part={1} />
-      </MaxWithBgColorContainer>
-      <MaxWithBgColorContainer bgColor="">
-        <MagicWhy part={2} />
-      </MaxWithBgColorContainer>
-      <MaxWithBgColorContainer bgColor="bg-ada-yellow3">
-        <MagicDateBanner version={2} />
-      </MaxWithBgColorContainer>
-      <MaxWithBgColorContainer bgColor="bg-ada-pink7">
-        <MagicWhy part={5} />
-      </MaxWithBgColorContainer>
-      <MaxWithBgColorContainer>
-        <MagicWhy part={6} />
+      <div id="top"></div>
+      <MaxWithBgColorContainer bgColor="bg-ada-white3">
+        <MagicSaleBanner version={6} />
       </MaxWithBgColorContainer>
       <MaxWithBgColorContainer bgColor="bg-ada-pink8">
-        <MagicWhy part={7} />
+        <MagicVideo version={2} />
       </MaxWithBgColorContainer>
-      <MaxWithBgColorContainer>
-        <MagicBanner1 version={2} />
-      </MaxWithBgColorContainer>
-      <MaxWithBgColorContainer bgColor="bg-ada-yellow3">
-        <MagicWhy part={3} />
-      </MaxWithBgColorContainer>
-      <MaxWithBgColorContainer bgColor="bg-ada-pink7">
-        <MagicWhy part={4} />
-      </MaxWithBgColorContainer>
-      <MaxWithBgColorContainer bgColor="bg-ada-yellow3 z-2 relative">
-        <MagicBioBanner version={2} />
+      <MaxWithBgColorContainer bgColor="bg-ada-white3">
+        <MagicBanner1 version={4} />
       </MaxWithBgColorContainer>
       <MaxWithBgColorContainer bgColor="bg-ada-pink8">
-        <MagicBanner2 version={1} />
+        <MagicWhy part={9} />
       </MaxWithBgColorContainer>
-      <MaxWithBgColorContainer bgColor="bg-ada-yellow3 z-2 relative">
-        <ReferencesMentoring title5 />
+      <MaxWithBgColorContainer bgColor="bg-ada-white3">
+        <MagicDateBanner version={3} />
       </MaxWithBgColorContainer>
-      <MaxWithBgColorContainer bgColor="bg-ada-purple2">
-        <MagicLastSection version={2} />
+      <MaxWithBgColorContainer bgColor="bg-ada-pink8">
+        <MagicDateBanner version={4} />
+      </MaxWithBgColorContainer>
+      <div id="magic-package"></div>
+      <MaxWithBgColorContainer bgColor="bg-ada-magicOrange2">
+        <MagicSaleBanner version={2} />
+      </MaxWithBgColorContainer>
+      <MaxWithBgColorContainer bgColor="bg-ada-white3">
+        <MagicWhy part={10} />
+      </MaxWithBgColorContainer>
+      <MaxWithBgColorContainer bgColor="bg-ada-pink8">
+        <MagicWhy part={11} />
+      </MaxWithBgColorContainer>
+      <MaxWithBgColorContainer bgColor="bg-ada-white3">
+        <MagicBioBanner version={3} />
+      </MaxWithBgColorContainer>
+      <MaxWithBgColorContainer bgColor="bg-ada-pink8">
+        <MagicBanner2 version={2} />
+      </MaxWithBgColorContainer>
+      <MaxWithBgColorContainer bgColor="bg-ada-white3">
+        <MagicCommunityOpinions />
       </MaxWithBgColorContainer>
       <MaxWithBgColorContainer bgColor="bg-ada-light-pink">
         <MasterclassFAQ version={5} />
+      </MaxWithBgColorContainer>
+      <MaxWithBgColorContainer bgColor="bg-ada-white3">
+        <MagicFinalCTA />
       </MaxWithBgColorContainer>
     </Layout>
   )
@@ -87,7 +66,7 @@ const MagicNagraniePage = () => {
 
 export const Head = () => (
   <SEO
-    title="Magic: Poznaj… Meta Ads Girls Inside Club"
+    title="Obejrzyj nagranie z masterclassu!"
     image="https://adrianna.com.pl/img/ada_purple.webp"
   />
 )


### PR DESCRIPTION
Create a new page `/magic-nagranie` by copying `/magic`, updating the header, removing the community section, and replacing the video to feature a masterclass recording.

New versions of `MagicSaleBanner` and `MagicVideo` components were introduced to allow for specific content modifications on the `/magic-nagranie` page without affecting the original `/magic` page.

---
[Slack Thread](https://getboldworkspace.slack.com/archives/CKVBMQHJ5/p1757581337478999?thread_ts=1757581337.478999&cid=CKVBMQHJ5)

<a href="https://cursor.com/background-agent?bcId=bc-9eaa846e-bae8-45a6-9922-d4a225b28ac7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9eaa846e-bae8-45a6-9922-d4a225b28ac7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

