### PR TITLE
Update magic page header and countdown

### DIFF
--- a/src/components/CountdownBanner2/index.tsx
+++ b/src/components/CountdownBanner2/index.tsx
@@ -29,7 +29,7 @@ const CountdownBanner2: React.FC = () => {
           variant="h3"
           className="text-ada-pink7 text-xl md:text-2xl font-bold mb-2"
         >
-          UWAGA! Ten produkt jest dostępny za 0zł jedynie do 17.09 - zdecyduj się teraz!
+          Nie czekaj - drzwi do MAGIC zamykają się już za:
         </Typography>
         <CountdownTimer targetDate={targetDate} color="bg-ada-magicPink3" />
       </div>


### PR DESCRIPTION
Update the countdown banner heading text on the `/magic` page to reflect the closing of MAGIC doors.

---
[Slack Thread](https://getboldworkspace.slack.com/archives/CKVBMQHJ5/p1757949517866079?thread_ts=1757949517.866079&cid=CKVBMQHJ5)

<a href="https://cursor.com/background-agent?bcId=bc-8105cc73-48ea-46c6-9972-dfc4bdc41e06">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8105cc73-48ea-46c6-9972-dfc4bdc41e06">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

