### PR TITLE
Add section id and generate link

### DIFF
--- a/src/components/MagicCommunityOpinions/index.tsx
+++ b/src/components/MagicCommunityOpinions/index.tsx
@@ -5,7 +5,7 @@ import Typography from "../shared/Typography"
 
 const MagicCommunityOpinions = () => {
   return (
-    <Section bgColor="bg-transparent" className="pt-24 md:pt-32">
+    <Section bgColor="bg-transparent" className="pt-24 md:pt-32" id="opinie">
       <div className="w-full">
         <Typography variant="h1" className="mb-12 text-center text-ada-black">
           Zobacz, co członkinie <span className="text-ada-pink7">MAGIC</span>{" "}


### PR DESCRIPTION
Add `id="opinie"` to the MagicCommunityOpinions section to enable direct linking to it.

---
[Slack Thread](https://getboldworkspace.slack.com/archives/CKVBMQHJ5/p1758180124643129?thread_ts=1758180124.643129&cid=CKVBMQHJ5)

<a href="https://cursor.com/background-agent?bcId=bc-e8c7d843-9ee2-494d-8761-bc76c59e2b55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e8c7d843-9ee2-494d-8761-bc76c59e2b55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

