### PR TITLE
Reduce vertical padding in second section on advantage page

### DIFF
--- a/src/components/TrainingLandingPage/index.tsx
+++ b/src/components/TrainingLandingPage/index.tsx
@@ -102,7 +102,7 @@ const TrainingLandingPage = ({
       </MaxWithBgColorContainer>
 
       <MaxWithBgColorContainer bgColor="bg-ada-magicPink3">
-        <div className="pt-16 pb-4 flex flex-col lg:flex-row justify-between items-start gap-8 px-4">
+        <div className="py-4 flex flex-col lg:flex-row justify-between items-start gap-8 px-4">
           <div className="w-full lg:w-1/2 ">
             <h2 className="inline-block text-[48px] font-anton font-normal text-black bg-ada-magicOrange2 uppercase leading-none mb-8">
               {sectionTitle || "mini-kurs za 0zł"}


### PR DESCRIPTION
Changed padding from pt-16 pb-4 to py-4 to move the graphic up and create balanced thin strips of color on both top and bottom.

https://claude.ai/code/session_011c3kSuKNoFND6tEPFgyNa8