### PR TITLE
Add countdown timer and slide-in animations to wyzwanie page

### DIFF
--- a/src/helpers/CountdownTimer/index.tsx
+++ b/src/helpers/CountdownTimer/index.tsx
@@ -4,13 +4,17 @@ interface CountdownTimerProps {
   targetDate: Date
   text?: string
   color?: string
+  textColor?: string
 }
 
-const TimeSegment: React.FC<{ label: string; value: number }> = ({
-  label,
-  value,
-}) => (
-  <div className="flex flex-col items-center font-bold text-sm sm:text-base md:text-adaBase">
+const TimeSegment: React.FC<{
+  label: string
+  value: number
+  textColor?: string
+}> = ({ label, value, textColor }) => (
+  <div
+    className={`flex flex-col items-center font-bold text-sm sm:text-base md:text-adaBase ${textColor || ""}`}
+  >
     <p className="font-medium">{label}</p>
     <div className="text-xl sm:text-2xl">
       {value.toString().padStart(2, "0")}
@@ -22,6 +26,7 @@ const CountdownTimer: React.FC<CountdownTimerProps> = ({
   targetDate,
   text,
   color,
+  textColor,
 }) => {
   const calculateTimeLeft = () => {
     const difference = +targetDate - +new Date()
@@ -57,8 +62,10 @@ const CountdownTimer: React.FC<CountdownTimerProps> = ({
   return (
     <div className="flex flex-col items-center px-2 sm:px-4">
       {text && (
-        <p className="mb-2 text-lg sm:text-xl md:text-2xl font-bold text-center">
-          ✨ {text} ✨
+        <p
+          className={`mb-2 text-lg sm:text-xl md:text-2xl font-bold text-center ${textColor || ""}`}
+        >
+          {text}
         </p>
       )}
       <div
@@ -66,10 +73,22 @@ const CountdownTimer: React.FC<CountdownTimerProps> = ({
         style={!isTailwindClass && color ? { backgroundColor: color } : {}}
       >
         {" "}
-        <TimeSegment label="DNI" value={timeLeft.days} />
-        <TimeSegment label="GODZIN" value={timeLeft.hours} />
-        <TimeSegment label="MINUT" value={timeLeft.minutes} />
-        <TimeSegment label="SEKUND" value={timeLeft.seconds} />
+        <TimeSegment label="DNI" value={timeLeft.days} textColor={textColor} />
+        <TimeSegment
+          label="GODZIN"
+          value={timeLeft.hours}
+          textColor={textColor}
+        />
+        <TimeSegment
+          label="MINUT"
+          value={timeLeft.minutes}
+          textColor={textColor}
+        />
+        <TimeSegment
+          label="SEKUND"
+          value={timeLeft.seconds}
+          textColor={textColor}
+        />
       </div>
     </div>
   )

--- a/src/pages/wyzwanie.tsx
+++ b/src/pages/wyzwanie.tsx
@@ -201,7 +201,39 @@ const wyzwanieDays: WyzwanieDay[] = [
   },
 ]
 
-const WyzwanieDaySection = ({ day }: { day: WyzwanieDay }) => {
+const useInView = () => {
+  const ref = React.useRef<HTMLDivElement>(null)
+  const [isInView, setIsInView] = React.useState(false)
+
+  React.useEffect(() => {
+    if (typeof window === "undefined" || !("IntersectionObserver" in window)) {
+      setIsInView(true)
+      return
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsInView(true)
+          observer.disconnect()
+        }
+      },
+      { threshold: 0.2 }
+    )
+
+    const currentRef = ref.current
+    if (currentRef) {
+      observer.observe(currentRef)
+    }
+
+    return () => observer.disconnect()
+  }, [])
+
+  return { ref, isInView }
+}
+
+const WyzwanieDaySection = ({ day, index }: { day: WyzwanieDay; index: number }) => {
+  const { ref, isInView } = useInView()
   const isFull = day.side === "full"
   const isRight = day.side === "right"
   const pillExtraPadding = isFull
@@ -216,10 +248,12 @@ const WyzwanieDaySection = ({ day }: { day: WyzwanieDay }) => {
       : "lg:pr-[240px]"
   const portraitPosition = isRight ? "lg:-left-2" : "lg:-right-2"
 
+  const slideAnimation = index % 2 === 0 ? "animate-slideInFromLeft" : "animate-slideInFromRight"
+
   return (
     <MaxWithBgColorContainer bgColor={day.sectionBg}>
-      <div className="px-4 py-10 lg:py-12">
-        <div className="mx-auto flex w-full max-w-5xl flex-col items-center lg:w-1/2 lg:max-w-none">
+      <div ref={ref} className="px-4 py-10 lg:py-12 overflow-hidden">
+        <div className={`mx-auto flex w-full max-w-5xl flex-col items-center lg:w-1/2 lg:max-w-none ${isInView ? slideAnimation : "opacity-0"}`}>
           <div
             className={`relative w-full ${isFull ? "" : "lg:min-h-[220px]"}`}
           >
@@ -278,8 +312,8 @@ const WyzwanieDaySection = ({ day }: { day: WyzwanieDay }) => {
 
 const wyzwanieBeforeBenefitsSection = (
   <>
-    {wyzwanieDays.map((day) => (
-      <WyzwanieDaySection key={day.number} day={day} />
+    {wyzwanieDays.map((day, index) => (
+      <WyzwanieDaySection key={day.number} day={day} index={index} />
     ))}
     {/* SPRAWDZAM button positioned between purple and light sections */}
     <div className="relative">

--- a/src/values/wyzwanieLanding.tsx
+++ b/src/values/wyzwanieLanding.tsx
@@ -1,7 +1,9 @@
+import CountdownTimer from "helpers/CountdownTimer"
 import React from "react"
 
 export const WYZWANIE_PAGE_TITLE = "Kampania sprzedażowa w pigułce - Wyzwanie"
 export const wyzwanieHeroBgColor = "bg-ada-magicYellow"
+export const WYZWANIE_START_DATE = new Date("2026-04-20T00:00:00")
 
 export const wyzwanieBenefits = [
   {
@@ -58,6 +60,14 @@ export const wyzwanieHeroLeft = (
       <span className="inline-block bg-white px-4 py-2 text-[18px] lg:text-[20px] font-normal leading-[140%] text-black">
         kampania sprzedażowa.
       </span>
+    </div>
+    <div className="mt-6">
+      <CountdownTimer
+        targetDate={WYZWANIE_START_DATE}
+        text="wyzwanie startuje za"
+        color="bg-black"
+        textColor="text-white"
+      />
     </div>
   </>
 )


### PR DESCRIPTION
- Add black countdown timer with white text below hero subtitle showing time until challenge start (April 20, 2026)
- Add slide-in animations to day sections: odd sections slide from left, even sections slide from right when they come into view
- Update CountdownTimer component to support custom text color prop

https://claude.ai/code/session_01S1u7xKLayc4xTLFYpUnYGq