### PR TITLE
Fix expert portrait positions on wyzwanie page

### DIFF
--- a/src/pages/wyzwanie.tsx
+++ b/src/pages/wyzwanie.tsx
@@ -237,14 +237,14 @@ const WyzwanieDaySection = ({ day, index }: { day: WyzwanieDay; index: number })
   const pillExtraPadding = isFull
     ? ""
     : isRight
-      ? "lg:pl-[230px]"
-      : "lg:pr-[230px]"
+      ? "lg:pr-[230px]"
+      : "lg:pl-[230px]"
   const subtitleExtraPadding = isFull
     ? ""
     : isRight
-      ? "lg:pl-[250px]"
-      : "lg:pr-[250px]"
-  const portraitPosition = isRight ? "lg:left-0" : "lg:right-0"
+      ? "lg:pr-[250px]"
+      : "lg:pl-[250px]"
+  const portraitPosition = isRight ? "lg:right-0" : "lg:left-0"
 
   const slideAnimation = index % 2 === 0 ? "animate-slideInFromLeft" : "animate-slideInFromRight"
 


### PR DESCRIPTION
Flip portrait positioning so photos appear on the same side as their content alignment (left portraits for left-aligned days, right portraits for right-aligned days).

https://claude.ai/code/session_01WHqHN7M77kae1xvLG1Uu5o