### PR TITLE
Fix typo: add missing space in "konsultacji grupowych miesięcznie"

### DIFF
--- a/src/components/MagicSaleBanner/index.tsx
+++ b/src/components/MagicSaleBanner/index.tsx
@@ -119,7 +119,7 @@ const MagicSaleBanner = ({
             <div>
               <p className="pb-4">
                 🗓️ udział w dwóch{" "}
-                <b>1,5-godzinnych sesjach konsultacji grupowych</b>
+                <b>1,5-godzinnych sesjach konsultacji grupowych</b>{" "}
                 miesięcznie
               </p>
               <p className="pb-4">


### PR DESCRIPTION
The text was missing a space between "grupowych" and "miesięcznie".

https://claude.ai/code/session_0124VRQs8NxCSzzgaxrEXYiC