### PR TITLE
Update magic-special page: white section bg, custom column colors

### DIFF
--- a/src/components/MagicSaleBanner/index.tsx
+++ b/src/components/MagicSaleBanner/index.tsx
@@ -7,9 +7,13 @@ import Section from "../shared/Section"
 const MagicSaleBanner = ({
   version,
   url,
+  column2BgColor = "bg-ada-white3",
+  column3BgColor = "bg-ada-white3",
 }: {
   version: number
   url?: string
+  column2BgColor?: string
+  column3BgColor?: string
 }) => {
   return (
     <>
@@ -154,7 +158,7 @@ const MagicSaleBanner = ({
                   Buduj z MAGIC
                 </p>
               </div>
-              <div className="xl:text-adaDesc flex flex-col bg-ada-white3 rounded-[24px] text-black text-left p-8 shadow-xl flex-1 w-full">
+              <div className={`xl:text-adaDesc flex flex-col ${column2BgColor} rounded-[24px] text-black text-left p-8 shadow-xl flex-1 w-full`}>
                 <p className="pb-4">
                   👩‍💻 <b>konsultacje pisemne</b> z ekspertkami
                 </p>
@@ -201,7 +205,7 @@ const MagicSaleBanner = ({
                   Skaluj z MAGIC
                 </p>
               </div>
-              <div className="xl:text-adaDesc flex flex-col bg-ada-white3 rounded-[24px] text-black text-left p-8 shadow-xl flex-1 w-full">
+              <div className={`xl:text-adaDesc flex flex-col ${column3BgColor} rounded-[24px] text-black text-left p-8 shadow-xl flex-1 w-full`}>
                 <p className="pb-4">
                   👩‍💻 <b>konsultacje pisemne</b> z ekspertkami
                 </p>

--- a/src/pages/magic-special.tsx
+++ b/src/pages/magic-special.tsx
@@ -38,10 +38,12 @@ const MagicSpecialPage = () => {
         <MagicDateBanner version={4} />
       </MaxWithBgColorContainer>
       <div id="magic-package"></div>
-      <MaxWithBgColorContainer bgColor="bg-ada-magicOrange2">
+      <MaxWithBgColorContainer bgColor="bg-white">
         <MagicSaleBanner
           version={2}
           url="https://slowmarketing.zanfia.co/c/sesame/magic-pakiet-basic-rXx5?variant=ad0a7a4d-a612-4afc-870d-d1a660b44872"
+          column2BgColor="bg-[#F5CEE2]"
+          column3BgColor="bg-[#E8F6CD]"
         />
       </MaxWithBgColorContainer>
       <div className="bg-magic">


### PR DESCRIPTION
Changes to "dołącz do MAGIC" section on /magic-special/:
- Section background changed from orange to white (#FFFFFF)
- Second column ("Buduj z MAGIC") background: #F5CEE2
- Third column ("Skaluj z MAGIC") background: #E8F6CD

Slack thread: https://getboldworkspace.slack.com/archives/CKVBMQHJ5/p1776419359202189

https://claude.ai/code/session_01R7d7sAKHonmfFgbEufpzyx