### PR TITLE
Move subscription headers inside pricing columns on magic-special page

### DIFF
--- a/src/components/MagicSaleBanner/index.tsx
+++ b/src/components/MagicSaleBanner/index.tsx
@@ -103,13 +103,13 @@ const MagicSaleBanner = ({
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 w-full max-w-[1200px] mt-8">
             {/* Column 1: Pakiet miesięczny */}
             <div className="flex flex-col items-center">
-              <div className="mb-4 text-center">
-                <p className="text-adaDesc">subskrypcja miesięczna</p>
-                <p className="text-adaSubtitle font-bold uppercase">TESTUJ Z MAGIC</p>
-                <p className="text-adaDesc">cena</p>
-                <p className="text-adaSubtitle font-bold">509 ZŁ/MIESIĄC</p>
-              </div>
               <div className="xl:text-adaDesc flex flex-col bg-ada-white3 rounded-[24px] text-black text-left p-8 shadow-xl flex-1 w-full">
+                <div className="mb-4 text-center">
+                  <p className="text-adaDesc">subskrypcja miesięczna</p>
+                  <p className="text-adaSubtitle font-bold uppercase">TESTUJ Z MAGIC</p>
+                  <p className="text-adaDesc">cena</p>
+                  <p className="text-adaSubtitle font-bold">509 ZŁ/MIESIĄC</p>
+                </div>
                 <p className="pb-4">
                   👩‍💻 <b>konsultacje pisemne</b> z ekspertkami
                 </p>
@@ -148,13 +148,13 @@ const MagicSaleBanner = ({
 
             {/* Column 2: Buduj z MAGIC */}
             <div className="flex flex-col items-center">
-              <div className="mb-4 text-center">
-                <p className="text-adaDesc">subskrypcja miesięczna</p>
-                <p className="text-adaSubtitle font-bold uppercase">BUDUJ Z MAGIC</p>
-                <p className="text-adaDesc">cena</p>
-                <p className="text-adaSubtitle font-bold">409 ZŁ/MIESIĄC</p>
-              </div>
               <div className={`xl:text-adaDesc flex flex-col ${column2BgColor} rounded-[24px] text-black text-left p-8 shadow-xl flex-1 w-full`}>
+                <div className="mb-4 text-center">
+                  <p className="text-adaDesc">subskrypcja miesięczna</p>
+                  <p className="text-adaSubtitle font-bold uppercase">BUDUJ Z MAGIC</p>
+                  <p className="text-adaDesc">cena</p>
+                  <p className="text-adaSubtitle font-bold">409 ZŁ/MIESIĄC</p>
+                </div>
                 <p className="pb-4">
                   👩‍💻 <b>konsultacje pisemne</b> z ekspertkami
                 </p>
@@ -193,13 +193,13 @@ const MagicSaleBanner = ({
 
             {/* Column 3: Skaluj z MAGIC */}
             <div className="flex flex-col items-center">
-              <div className="mb-4 text-center">
-                <p className="text-adaDesc">subskrypcja miesięczna</p>
-                <p className="text-adaSubtitle font-bold uppercase">SKALUJ Z MAGIC</p>
-                <p className="text-adaDesc">cena</p>
-                <p className="text-adaSubtitle font-bold">379 ZŁ/MIESIĄC</p>
-              </div>
               <div className={`xl:text-adaDesc flex flex-col ${column3BgColor} rounded-[24px] text-black text-left p-8 shadow-xl flex-1 w-full`}>
+                <div className="mb-4 text-center">
+                  <p className="text-adaDesc">subskrypcja miesięczna</p>
+                  <p className="text-adaSubtitle font-bold uppercase">SKALUJ Z MAGIC</p>
+                  <p className="text-adaDesc">cena</p>
+                  <p className="text-adaSubtitle font-bold">379 ZŁ/MIESIĄC</p>
+                </div>
                 <p className="pb-4">
                   👩‍💻 <b>konsultacje pisemne</b> z ekspertkami
                 </p>


### PR DESCRIPTION
Headers (subscription type, plan name, price) are now displayed inside
each colored pricing box, centered above the feature list.

Slack thread: https://getboldworkspace.slack.com/archives/CKVBMQHJ5/p1776421217671869?thread_ts=1776421111.146179&cid=CKVBMQHJ5

https://claude.ai/code/session_01JW1aobsqXDWYxKCeNhViBA