### PR TITLE
Style magic-special pricing section per design feedback

### DIFF
--- a/src/components/MagicSaleBanner/index.tsx
+++ b/src/components/MagicSaleBanner/index.tsx
@@ -95,8 +95,8 @@ const MagicSaleBanner = ({
             textStyle="text-adaTitle text-black font-bold"
             as="h2"
           />
-          <p className="text-adaSubtitle mt-4 text-[#000000] bg-[#FFD1F0] px-4 py-2 rounded-lg">
-            <b>3 opcje czasowe subskrypcji</b> - wybierz model najlepszy dla Ciebie!
+          <p className="text-adaSubtitle mt-4 text-[#000000]">
+            <span className="bg-[#FFD1F0] px-4 py-2 rounded-lg inline"><b>3 opcje czasowe subskrypcji</b> - wybierz model najlepszy dla Ciebie!</span>
           </p>
 
           {/* 3-column pricing grid */}
@@ -106,9 +106,9 @@ const MagicSaleBanner = ({
               <div className="xl:text-adaDesc flex flex-col bg-ada-white3 rounded-[24px] text-black text-left p-8 shadow-xl flex-1 w-full border border-black">
                 <div className="mb-4 text-left">
                   <p className="text-adaDesc">subskrypcja miesięczna</p>
-                  <p className="text-adaSubtitle font-bold uppercase">TESTUJ Z MAGIC</p>
+                  <p className="text-adaSubtitleSecondary font-bold uppercase">TESTUJ Z MAGIC</p>
                   <p className="text-adaDesc">cena</p>
-                  <p className="text-adaSubtitle font-bold">509 ZŁ/MIESIĄC</p>
+                  <p><span className="text-adaSubtitleSecondary font-bold">509</span> <span className="text-adaBase font-bold">ZŁ/MIESIĄC</span></p>
                 </div>
                 <div className="mb-6 text-center">
                   <Button
@@ -122,26 +122,26 @@ const MagicSaleBanner = ({
                     btnStyle="bg-ada-magicPink4 tracking-wide p-3 hover:opacity-90 rounded-full min-w-[180px] h-[56px] shadow-xl"
                   />
                 </div>
-                <hr className="border-t border-black mb-4" />
-                <p className="pb-4">
+                <hr className="border-t border-black mb-4 -mx-8" />
+                <p className="pb-4 text-base">
                   👩‍💻 <b>konsultacje pisemne</b> z ekspertkami
                 </p>
-                <p className="pb-4">
+                <p className="pb-4 text-base">
                   🎥 <b>materiały szkoleniowe video</b> z ustawiania kampanii
                   reklamowych i nie tylko
                 </p>
-                <p className="pb-4">
+                <p className="pb-4 text-base">
                   🚀 dostęp do <b>wewnętrznej bazy wiedzy</b>
                 </p>
-                <p className="pb-4">
+                <p className="pb-4 text-base">
                   🗓️ udział w dwóch{" "}
                   <b>1,5-godzinnych sesjach konsultacji grupowych</b> miesięcznie
                 </p>
-                <p className="pb-4">
+                <p className="pb-4 text-base">
                   💡 udział w dwóch <b>autorskich warsztatach tematycznych</b> w
                   miesiącu
                 </p>
-                <p>
+                <p className="text-base">
                   👀 <b>nielimitowany dostęp do nagrań</b> ze wszystkich spotkań
                 </p>
               </div>
@@ -152,9 +152,9 @@ const MagicSaleBanner = ({
               <div className={`xl:text-adaDesc flex flex-col ${column2BgColor} rounded-[24px] text-black text-left p-8 shadow-xl flex-1 w-full border border-black`}>
                 <div className="mb-4 text-left">
                   <p className="text-adaDesc">subskrypcja 3-miesięczna</p>
-                  <p className="text-adaSubtitle font-bold uppercase">BUDUJ Z MAGIC</p>
+                  <p className="text-adaSubtitleSecondary font-bold uppercase">BUDUJ Z MAGIC</p>
                   <p className="text-adaDesc">cena</p>
-                  <p className="text-adaSubtitle font-bold">409 ZŁ/MIESIĄC</p>
+                  <p><span className="text-adaSubtitleSecondary font-bold">409</span> <span className="text-adaBase font-bold">ZŁ/MIESIĄC</span></p>
                 </div>
                 <div className="mb-6 text-center">
                   <Button
@@ -168,26 +168,26 @@ const MagicSaleBanner = ({
                     btnStyle="bg-ada-magicPink4 tracking-wide p-3 hover:opacity-90 rounded-full min-w-[180px] h-[56px] shadow-xl"
                   />
                 </div>
-                <hr className="border-t border-black mb-4" />
-                <p className="pb-4">
+                <hr className="border-t border-black mb-4 -mx-8" />
+                <p className="pb-4 text-base">
                   👩‍💻 <b>konsultacje pisemne</b> z ekspertkami
                 </p>
-                <p className="pb-4">
+                <p className="pb-4 text-base">
                   🎥 <b>materiały szkoleniowe video</b> z ustawiania kampanii
                   reklamowych i nie tylko
                 </p>
-                <p className="pb-4">
+                <p className="pb-4 text-base">
                   🚀 dostęp do <b>wewnętrznej bazy wiedzy</b>
                 </p>
-                <p className="pb-4">
+                <p className="pb-4 text-base">
                   🗓️ udział w dwóch{" "}
                   <b>1,5-godzinnych sesjach konsultacji grupowych</b> miesięcznie
                 </p>
-                <p className="pb-4">
+                <p className="pb-4 text-base">
                   💡 udział w dwóch <b>autorskich warsztatach tematycznych</b> w
                   miesiącu
                 </p>
-                <p>
+                <p className="text-base">
                   👀 <b>nielimitowany dostęp do nagrań</b> ze wszystkich spotkań
                 </p>
               </div>
@@ -198,9 +198,9 @@ const MagicSaleBanner = ({
               <div className={`xl:text-adaDesc flex flex-col ${column3BgColor} rounded-[24px] text-black text-left p-8 shadow-xl flex-1 w-full border border-black`}>
                 <div className="mb-4 text-left">
                   <p className="text-adaDesc">subskrypcja 6-miesięczna</p>
-                  <p className="text-adaSubtitle font-bold uppercase">SKALUJ Z MAGIC</p>
+                  <p className="text-adaSubtitleSecondary font-bold uppercase">SKALUJ Z MAGIC</p>
                   <p className="text-adaDesc">cena</p>
-                  <p className="text-adaSubtitle font-bold">379 ZŁ/MIESIĄC</p>
+                  <p><span className="text-adaSubtitleSecondary font-bold">379</span> <span className="text-adaBase font-bold">ZŁ/MIESIĄC</span></p>
                 </div>
                 <div className="mb-6 text-center">
                   <Button
@@ -214,26 +214,26 @@ const MagicSaleBanner = ({
                     btnStyle="bg-ada-magicPink4 tracking-wide p-3 hover:opacity-90 rounded-full min-w-[180px] h-[56px] shadow-xl"
                   />
                 </div>
-                <hr className="border-t border-black mb-4" />
-                <p className="pb-4">
+                <hr className="border-t border-black mb-4 -mx-8" />
+                <p className="pb-4 text-base">
                   👩‍💻 <b>konsultacje pisemne</b> z ekspertkami
                 </p>
-                <p className="pb-4">
+                <p className="pb-4 text-base">
                   🎥 <b>materiały szkoleniowe video</b> z ustawiania kampanii
                   reklamowych i nie tylko
                 </p>
-                <p className="pb-4">
+                <p className="pb-4 text-base">
                   🚀 dostęp do <b>wewnętrznej bazy wiedzy</b>
                 </p>
-                <p className="pb-4">
+                <p className="pb-4 text-base">
                   🗓️ udział w dwóch{" "}
                   <b>1,5-godzinnych sesjach konsultacji grupowych</b> miesięcznie
                 </p>
-                <p className="pb-4">
+                <p className="pb-4 text-base">
                   💡 udział w dwóch <b>autorskich warsztatach tematycznych</b> w
                   miesiącu
                 </p>
-                <p>
+                <p className="text-base">
                   👀 <b>nielimitowany dostęp do nagrań</b> ze wszystkich spotkań
                 </p>
               </div>


### PR DESCRIPTION
- Make background on subtitle text inline (only behind the text)
- Extend horizontal line to touch column borders with -mx-8
- Increase titles (TESTUJ/BUDUJ/SKALUJ Z MAGIC) and prices (509/409/379) to text-adaSubtitleSecondary
- Reduce ZŁ/MIESIĄC to text-adaBase
- Reduce feature list text to text-base

Slack thread: https://getboldworkspace.slack.com/archives/CKVBMQHJ5/p1776422942378219?thread_ts=1776422932.670189&cid=CKVBMQHJ5

https://claude.ai/code/session_01HWSegkcH5qqmnUJxN7iBt4