### PR TITLE
Adjust magic-special pricing section typography and layout

### DIFF
--- a/src/components/MagicSaleBanner/index.tsx
+++ b/src/components/MagicSaleBanner/index.tsx
@@ -96,7 +96,7 @@ const MagicSaleBanner = ({
             as="h2"
           />
           <p className="text-adaSubtitle mt-4 text-[#000000]">
-            <span className="bg-[#FFD1F0] px-4 py-2 rounded-lg inline"><b>3 opcje czasowe subskrypcji</b> - wybierz model najlepszy dla Ciebie!</span>
+            <span className="bg-[#FFD1F0] px-4 py-2 rounded-lg inline-block"><b>3 opcje czasowe subskrypcji</b> - wybierz model najlepszy dla Ciebie!</span>
           </p>
 
           {/* 3-column pricing grid */}
@@ -106,9 +106,9 @@ const MagicSaleBanner = ({
               <div className="xl:text-adaDesc flex flex-col bg-ada-white3 rounded-[24px] text-black text-left p-8 shadow-xl flex-1 w-full border border-black">
                 <div className="mb-4 text-left">
                   <p className="text-adaDesc">subskrypcja miesięczna</p>
-                  <p className="text-adaSubtitleSecondary font-bold uppercase">TESTUJ Z MAGIC</p>
+                  <p className="text-adaSubtitleThird font-bold uppercase">TESTUJ Z MAGIC</p>
                   <p className="text-adaDesc">cena</p>
-                  <p><span className="text-adaSubtitleSecondary font-bold">509</span> <span className="text-adaBase font-bold">ZŁ/MIESIĄC</span></p>
+                  <p><span className="text-adaSubtitleThird font-bold">509</span> <span className="text-adaDesc font-bold">ZŁ/MIESIĄC</span></p>
                 </div>
                 <div className="mb-6 text-center">
                   <Button
@@ -122,26 +122,26 @@ const MagicSaleBanner = ({
                     btnStyle="bg-ada-magicPink4 tracking-wide p-3 hover:opacity-90 rounded-full min-w-[180px] h-[56px] shadow-xl"
                   />
                 </div>
-                <hr className="border-t border-black mb-4 -mx-8" />
-                <p className="pb-4 text-base">
+                <hr className="border-t border-black mb-4 w-[calc(100%+4rem)] -ml-8" />
+                <p className="pb-4 text-sm">
                   👩‍💻 <b>konsultacje pisemne</b> z ekspertkami
                 </p>
-                <p className="pb-4 text-base">
+                <p className="pb-4 text-sm">
                   🎥 <b>materiały szkoleniowe video</b> z ustawiania kampanii
                   reklamowych i nie tylko
                 </p>
-                <p className="pb-4 text-base">
+                <p className="pb-4 text-sm">
                   🚀 dostęp do <b>wewnętrznej bazy wiedzy</b>
                 </p>
-                <p className="pb-4 text-base">
+                <p className="pb-4 text-sm">
                   🗓️ udział w dwóch{" "}
                   <b>1,5-godzinnych sesjach konsultacji grupowych</b> miesięcznie
                 </p>
-                <p className="pb-4 text-base">
+                <p className="pb-4 text-sm">
                   💡 udział w dwóch <b>autorskich warsztatach tematycznych</b> w
                   miesiącu
                 </p>
-                <p className="text-base">
+                <p className="text-sm">
                   👀 <b>nielimitowany dostęp do nagrań</b> ze wszystkich spotkań
                 </p>
               </div>
@@ -152,9 +152,9 @@ const MagicSaleBanner = ({
               <div className={`xl:text-adaDesc flex flex-col ${column2BgColor} rounded-[24px] text-black text-left p-8 shadow-xl flex-1 w-full border border-black`}>
                 <div className="mb-4 text-left">
                   <p className="text-adaDesc">subskrypcja 3-miesięczna</p>
-                  <p className="text-adaSubtitleSecondary font-bold uppercase">BUDUJ Z MAGIC</p>
+                  <p className="text-adaSubtitleThird font-bold uppercase">BUDUJ Z MAGIC</p>
                   <p className="text-adaDesc">cena</p>
-                  <p><span className="text-adaSubtitleSecondary font-bold">409</span> <span className="text-adaBase font-bold">ZŁ/MIESIĄC</span></p>
+                  <p><span className="text-adaSubtitleThird font-bold">409</span> <span className="text-adaDesc font-bold">ZŁ/MIESIĄC</span></p>
                 </div>
                 <div className="mb-6 text-center">
                   <Button
@@ -168,26 +168,26 @@ const MagicSaleBanner = ({
                     btnStyle="bg-ada-magicPink4 tracking-wide p-3 hover:opacity-90 rounded-full min-w-[180px] h-[56px] shadow-xl"
                   />
                 </div>
-                <hr className="border-t border-black mb-4 -mx-8" />
-                <p className="pb-4 text-base">
+                <hr className="border-t border-black mb-4 w-[calc(100%+4rem)] -ml-8" />
+                <p className="pb-4 text-sm">
                   👩‍💻 <b>konsultacje pisemne</b> z ekspertkami
                 </p>
-                <p className="pb-4 text-base">
+                <p className="pb-4 text-sm">
                   🎥 <b>materiały szkoleniowe video</b> z ustawiania kampanii
                   reklamowych i nie tylko
                 </p>
-                <p className="pb-4 text-base">
+                <p className="pb-4 text-sm">
                   🚀 dostęp do <b>wewnętrznej bazy wiedzy</b>
                 </p>
-                <p className="pb-4 text-base">
+                <p className="pb-4 text-sm">
                   🗓️ udział w dwóch{" "}
                   <b>1,5-godzinnych sesjach konsultacji grupowych</b> miesięcznie
                 </p>
-                <p className="pb-4 text-base">
+                <p className="pb-4 text-sm">
                   💡 udział w dwóch <b>autorskich warsztatach tematycznych</b> w
                   miesiącu
                 </p>
-                <p className="text-base">
+                <p className="text-sm">
                   👀 <b>nielimitowany dostęp do nagrań</b> ze wszystkich spotkań
                 </p>
               </div>
@@ -198,9 +198,9 @@ const MagicSaleBanner = ({
               <div className={`xl:text-adaDesc flex flex-col ${column3BgColor} rounded-[24px] text-black text-left p-8 shadow-xl flex-1 w-full border border-black`}>
                 <div className="mb-4 text-left">
                   <p className="text-adaDesc">subskrypcja 6-miesięczna</p>
-                  <p className="text-adaSubtitleSecondary font-bold uppercase">SKALUJ Z MAGIC</p>
+                  <p className="text-adaSubtitleThird font-bold uppercase">SKALUJ Z MAGIC</p>
                   <p className="text-adaDesc">cena</p>
-                  <p><span className="text-adaSubtitleSecondary font-bold">379</span> <span className="text-adaBase font-bold">ZŁ/MIESIĄC</span></p>
+                  <p><span className="text-adaSubtitleThird font-bold">379</span> <span className="text-adaDesc font-bold">ZŁ/MIESIĄC</span></p>
                 </div>
                 <div className="mb-6 text-center">
                   <Button
@@ -214,26 +214,26 @@ const MagicSaleBanner = ({
                     btnStyle="bg-ada-magicPink4 tracking-wide p-3 hover:opacity-90 rounded-full min-w-[180px] h-[56px] shadow-xl"
                   />
                 </div>
-                <hr className="border-t border-black mb-4 -mx-8" />
-                <p className="pb-4 text-base">
+                <hr className="border-t border-black mb-4 w-[calc(100%+4rem)] -ml-8" />
+                <p className="pb-4 text-sm">
                   👩‍💻 <b>konsultacje pisemne</b> z ekspertkami
                 </p>
-                <p className="pb-4 text-base">
+                <p className="pb-4 text-sm">
                   🎥 <b>materiały szkoleniowe video</b> z ustawiania kampanii
                   reklamowych i nie tylko
                 </p>
-                <p className="pb-4 text-base">
+                <p className="pb-4 text-sm">
                   🚀 dostęp do <b>wewnętrznej bazy wiedzy</b>
                 </p>
-                <p className="pb-4 text-base">
+                <p className="pb-4 text-sm">
                   🗓️ udział w dwóch{" "}
                   <b>1,5-godzinnych sesjach konsultacji grupowych</b> miesięcznie
                 </p>
-                <p className="pb-4 text-base">
+                <p className="pb-4 text-sm">
                   💡 udział w dwóch <b>autorskich warsztatach tematycznych</b> w
                   miesiącu
                 </p>
-                <p className="text-base">
+                <p className="text-sm">
                   👀 <b>nielimitowany dostęp do nagrań</b> ze wszystkich spotkań
                 </p>
               </div>


### PR DESCRIPTION
- Subtitle background now only wraps text (inline-block)
- Extend horizontal lines to touch column borders
- Enlarge plan titles (TESTUJ/BUDUJ/SKALUJ Z MAGIC) and prices
- Reduce ZŁ/MIESIĄC and bullet point text sizes

https://claude.ai/code/session_01VHDUpog9bPp5PVoHkwmSyf