### PR TITLE
Update magic-special page: remove promo code, reduce opinions to 6 im…

### DIFF
--- a/src/components/MagicBanner/index.tsx
+++ b/src/components/MagicBanner/index.tsx
@@ -170,10 +170,6 @@ const magicBannerContent3 = [
           </span>
           <br /> Skonsultuj optymalizację budżetu w zależności od etapu lejka i
           branży.
-          <br />
-          <span className="font-bold">
-            Pssst! Sprawdź kod: ALOHOMORA w koszyku!
-          </span>
         </p>
       </>
     ),

--- a/src/components/MagicBioBanner/PersonBox.tsx
+++ b/src/components/MagicBioBanner/PersonBox.tsx
@@ -21,7 +21,7 @@ const PersonBox = ({
 }: PersonBoxProps) => {
   return (
     <div
-      className={`text-center ${textColor} flex flex-col justify-center items-center pt-4 md:max-w-[300px]`}
+      className={`text-center ${textColor} flex flex-col justify-center items-center pt-4 w-full max-w-[280px]`}
     >
       <div className="relative">
         <CircleImage circleKey={img} />
@@ -37,7 +37,7 @@ const PersonBox = ({
       <Typography variant="h3" className="mb-2 mt-2 whitespace-nowrap">
         {name}
       </Typography>
-      <p className="text-sm md:text-base leading-relaxed">{description}</p>
+      <p className="text-sm md:text-base leading-relaxed max-w-full">{description}</p>
     </div>
   )
 }

--- a/src/components/MagicCommunityOpinions/index.tsx
+++ b/src/components/MagicCommunityOpinions/index.tsx
@@ -82,6 +82,9 @@ const MagicCommunityOpinions = ({
               width={400}
               className="w-full"
             />
+          </div>
+
+          <div className="flex flex-col gap-0">
             <StaticImage
               src="../../images/magic_reference_sell_3.webp"
               alt="Opinia o społeczności MAGIC"
@@ -114,54 +117,6 @@ const MagicCommunityOpinions = ({
             />
             <StaticImage
               src="../../images/magic_reference_sell_6.webp"
-              alt="Opinia o społeczności MAGIC"
-              placeholder="blurred"
-              formats={["auto", "webp", "avif"]}
-              quality={75}
-              width={400}
-              className="w-full"
-            />
-            <StaticImage
-              src="../../images/magic_reference_sell_7.webp"
-              alt="Opinia o społeczności MAGIC"
-              placeholder="blurred"
-              formats={["auto", "webp", "avif"]}
-              quality={75}
-              width={400}
-              className="w-full"
-            />
-            <StaticImage
-              src="../../images/magic_reference_sell_8.webp"
-              alt="Opinia o społeczności MAGIC"
-              placeholder="blurred"
-              formats={["auto", "webp", "avif"]}
-              quality={75}
-              width={400}
-              className="w-full"
-            />
-          </div>
-
-          <div className="flex flex-col gap-0">
-            <StaticImage
-              src="../../images/magic_reference_sell_9.webp"
-              alt="Opinia o społeczności MAGIC"
-              placeholder="blurred"
-              formats={["auto", "webp", "avif"]}
-              quality={75}
-              width={400}
-              className="w-full"
-            />
-            <StaticImage
-              src="../../images/magic_reference_sell_10.webp"
-              alt="Opinia o społeczności MAGIC"
-              placeholder="blurred"
-              formats={["auto", "webp", "avif"]}
-              quality={75}
-              width={400}
-              className="w-full"
-            />
-            <StaticImage
-              src="../../images/magic_reference_sell_12.webp"
               alt="Opinia o społeczności MAGIC"
               placeholder="blurred"
               formats={["auto", "webp", "avif"]}


### PR DESCRIPTION
…ages, fix column widths

- Removed "Pssst! Sprawdź kod: ALOHOMORA w koszyku!" text
- Reduced community opinions section from 11 to 6 images
- Fixed PersonBox column width to prevent text overlap between team members

Slack thread: https://getboldworkspace.slack.com/archives/CKVBMQHJ5/p1776863974585139?thread_ts=1776863652.486619&cid=CKVBMQHJ5

https://claude.ai/code/session_01WQvU2Ak9SUXb8MdHMT6pq8