### PR TITLE
Implement OTO timer system for wyzwanie page

### DIFF
--- a/src/components/TrainingLandingPage/index.tsx
+++ b/src/components/TrainingLandingPage/index.tsx
@@ -104,6 +104,7 @@ type TrainingLandingPageProps = {
   heroFigure?: React.ReactNode
   heroOverlay?: React.ReactNode
   heroWrapperClassName?: string
+  centerLastRowBenefits?: boolean
 }
 
 const TrainingLandingPage = ({
@@ -122,8 +123,10 @@ const TrainingLandingPage = ({
   heroFigure,
   heroOverlay,
   heroWrapperClassName,
+  centerLastRowBenefits = false,
 }: TrainingLandingPageProps) => {
   const hasForm = Boolean(formHTML)
+  const orphanCount = centerLastRowBenefits ? benefits.length % 3 : 0
 
   return (
     <Layout showHeaderAndFooter={false}>
@@ -211,20 +214,39 @@ const TrainingLandingPage = ({
               </>
             )}
           </h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-6xl mx-auto">
-            {benefits.map((b, idx) => (
-              <div
-                key={`${b.title}-${idx}`}
-                className={`${b.bgClass} rounded-lg p-6 border border-black text-center`}
-              >
-                <h3 className="text-[16px] font-bold text-black mb-2 uppercase whitespace-pre-line">
-                  {b.title}
-                </h3>
-                <p className="text-[16px] font-normal text-black whitespace-pre-line">
-                  {b.description}
-                </p>
+          <div className="max-w-6xl mx-auto">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {benefits.slice(0, benefits.length - orphanCount).map((b, idx) => (
+                <div
+                  key={`${b.title}-${idx}`}
+                  className={`${b.bgClass} rounded-lg p-6 border border-black text-center`}
+                >
+                  <h3 className="text-[16px] font-bold text-black mb-2 uppercase whitespace-pre-line">
+                    {b.title}
+                  </h3>
+                  <p className="text-[16px] font-normal text-black whitespace-pre-line">
+                    {b.description}
+                  </p>
+                </div>
+              ))}
+            </div>
+            {orphanCount > 0 && (
+              <div className="flex justify-center gap-6 mt-6 flex-wrap">
+                {benefits.slice(benefits.length - orphanCount).map((b, idx) => (
+                  <div
+                    key={`${b.title}-orphan-${idx}`}
+                    className={`${b.bgClass} rounded-lg p-6 border border-black text-center w-full md:w-[calc(50%-12px)] lg:w-[calc(33.333%-16px)]`}
+                  >
+                    <h3 className="text-[16px] font-bold text-black mb-2 uppercase whitespace-pre-line">
+                      {b.title}
+                    </h3>
+                    <p className="text-[16px] font-normal text-black whitespace-pre-line">
+                      {b.description}
+                    </p>
+                  </div>
+                ))}
               </div>
-            ))}
+            )}
           </div>
         </div>
       </MaxWithBgColorContainer>

--- a/src/components/WyzwanieStickyCountdown/index.tsx
+++ b/src/components/WyzwanieStickyCountdown/index.tsx
@@ -1,54 +1,22 @@
-import React, { useEffect, useState } from "react"
-import { WYZWANIE_START_DATE } from "values/wyzwanieLanding"
-
-const OFFER_SECTION_ID = "oferta"
+import React from "react"
+import { useOtoTimer, OTO_URL } from "hooks/useOtoTimer"
 
 const WyzwanieStickyCountdown = () => {
-  const calculateTimeLeft = () => {
-    const difference = +WYZWANIE_START_DATE - +new Date()
-    let timeLeft = { days: 0, hours: 0, minutes: 0, seconds: 0 }
-
-    if (difference > 0) {
-      timeLeft = {
-        days: Math.floor(difference / (1000 * 60 * 60 * 24)),
-        hours: Math.floor((difference / (1000 * 60 * 60)) % 24),
-        minutes: Math.floor((difference / 1000 / 60) % 60),
-        seconds: Math.floor((difference / 1000) % 60),
-      }
-    }
-
-    return timeLeft
-  }
-
-  const [timeLeft, setTimeLeft] = useState(calculateTimeLeft())
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setTimeLeft(calculateTimeLeft())
-    }, 1000)
-
-    return () => clearTimeout(timer)
-  })
+  const { isOtoActive, timeLeft } = useOtoTimer()
 
   const padNumber = (num: number) => num.toString().padStart(2, "0")
+
+  if (!isOtoActive) {
+    return null
+  }
 
   return (
     <div className="fixed top-0 left-0 right-0 z-50 bg-black py-2 px-4">
       <div className="container mx-auto flex items-center justify-center gap-2 md:gap-4 flex-wrap">
         <span className="text-white text-sm md:text-lg font-semibold">
-          Zamykamy drzwi za
+          Dostęp do wyzwania za 67 zł - TYLKO przez 30 minut
         </span>
         <div className="flex items-center gap-1 md:gap-3 text-white font-bold">
-          <div className="flex flex-col items-center">
-            <span className="text-lg md:text-2xl">{padNumber(timeLeft.days)}</span>
-            <span className="text-[10px] md:text-xs uppercase">dni</span>
-          </div>
-          <span className="text-lg md:text-2xl">:</span>
-          <div className="flex flex-col items-center">
-            <span className="text-lg md:text-2xl">{padNumber(timeLeft.hours)}</span>
-            <span className="text-[10px] md:text-xs uppercase">godz</span>
-          </div>
-          <span className="text-lg md:text-2xl">:</span>
           <div className="flex flex-col items-center">
             <span className="text-lg md:text-2xl">{padNumber(timeLeft.minutes)}</span>
             <span className="text-[10px] md:text-xs uppercase">min</span>
@@ -59,17 +27,12 @@ const WyzwanieStickyCountdown = () => {
             <span className="text-[10px] md:text-xs uppercase">sek</span>
           </div>
         </div>
-        <button
-          onClick={() => {
-            const section = document.getElementById(OFFER_SECTION_ID)
-            if (section) {
-              section.scrollIntoView({ behavior: "smooth" })
-            }
-          }}
+        <a
+          href={OTO_URL}
           className="bg-ada-pink7 text-white font-anton uppercase text-sm md:text-lg px-4 md:px-6 py-1 md:py-2 rounded-full shadow-md hover:brightness-95 transition-all"
         >
           DOŁĄCZAM
-        </button>
+        </a>
       </div>
     </div>
   )

--- a/src/helpers/Button/index.tsx
+++ b/src/helpers/Button/index.tsx
@@ -2,7 +2,7 @@ import { Link } from "gatsby"
 import { StaticImage } from "gatsby-plugin-image"
 import React from "react"
 
-type ButtonVariant = "default" | "dark" | "offer"
+type ButtonVariant = "default" | "dark" | "offer" | "pink"
 
 interface Props {
   type: "button" | "submit" | "reset"
@@ -23,6 +23,8 @@ const VARIANT_STYLES: Record<ButtonVariant, string> = {
   dark: "bg-black text-ada-magicYellow rounded-full shadow-[0_16px_38px_rgba(0,0,0,0.18)]",
   offer:
     "bg-ada-magicOrange2 text-black rounded-[14px] shadow-[0_8px_16px_rgba(0,0,0,0.14)] transition-all duration-200 hover:brightness-95 hover:shadow-xl",
+  pink:
+    "bg-ada-pink7 text-white rounded-[14px] shadow-[0_8px_16px_rgba(0,0,0,0.14)] transition-all duration-200 hover:brightness-95 hover:shadow-xl",
 }
 
 export const Button: React.FC<Props> = ({

--- a/src/hooks/useOtoTimer.ts
+++ b/src/hooks/useOtoTimer.ts
@@ -1,0 +1,54 @@
+import { useState, useEffect, useCallback } from "react"
+
+const OTO_DURATION_MS = 30 * 60 * 1000 // 30 minutes
+const OTO_START_KEY = "wyzwanie_oto_start"
+
+export const useOtoTimer = () => {
+  const [isOtoActive, setIsOtoActive] = useState(true)
+  const [timeLeft, setTimeLeft] = useState({ minutes: 30, seconds: 0 })
+
+  const getStartTime = useCallback(() => {
+    if (typeof window === "undefined") return null
+    const stored = localStorage.getItem(OTO_START_KEY)
+    if (stored) {
+      return parseInt(stored, 10)
+    }
+    const now = Date.now()
+    localStorage.setItem(OTO_START_KEY, now.toString())
+    return now
+  }, [])
+
+  useEffect(() => {
+    const startTime = getStartTime()
+    if (!startTime) return
+
+    const updateTimer = () => {
+      const elapsed = Date.now() - startTime
+      const remaining = OTO_DURATION_MS - elapsed
+
+      if (remaining <= 0) {
+        setIsOtoActive(false)
+        setTimeLeft({ minutes: 0, seconds: 0 })
+        return
+      }
+
+      setIsOtoActive(true)
+      setTimeLeft({
+        minutes: Math.floor(remaining / 60000),
+        seconds: Math.floor((remaining % 60000) / 1000),
+      })
+    }
+
+    updateTimer()
+    const interval = setInterval(updateTimer, 1000)
+    return () => clearInterval(interval)
+  }, [getStartTime])
+
+  return { isOtoActive, timeLeft }
+}
+
+export const OTO_PRICE = "67 zł"
+export const OTO_OLD_PRICE = "119 zł"
+export const REGULAR_PRICE = "119 zł"
+export const OTO_URL = "https://easl.ink/v62RG"
+export const REGULAR_URL = "https://easl.ink/Yib03"

--- a/src/pages/wyzwanie.tsx
+++ b/src/pages/wyzwanie.tsx
@@ -6,6 +6,14 @@ import { StaticImage } from "gatsby-plugin-image"
 import { Accordion } from "helpers/Accordion"
 import { Button } from "helpers/Button"
 import YellowCircleArrow from "helpers/YellowCircleArrow"
+import {
+  useOtoTimer,
+  OTO_PRICE,
+  OTO_OLD_PRICE,
+  REGULAR_PRICE,
+  OTO_URL,
+  REGULAR_URL,
+} from "hooks/useOtoTimer"
 import React from "react"
 import {
   WYZWANIE_PAGE_TITLE,
@@ -15,7 +23,6 @@ import {
 } from "values/wyzwanieLanding"
 
 const OFFER_SECTION_ID = "oferta"
-const WYZWANIE_CHECKOUT_URL = "https://easl.ink/Yib03"
 
 const wyzwanieHeroFigure = (
   <div className="relative z-10 flex justify-center items-center">
@@ -257,7 +264,7 @@ const WyzwanieDaySection = ({ day, index }: { day: WyzwanieDay; index: number })
                 }`}
               >
                 <p
-                  className={`font-anton font-bold uppercase leading-none text-black ${
+                  className={`font-anton font-normal uppercase leading-none text-black ${
                     isFull
                       ? "text-[22px] lg:text-[42px]"
                       : "text-[24px] lg:text-adaTitle"
@@ -708,75 +715,89 @@ const WyzwanieStartSection = () => (
   </MaxWithBgColorContainer>
 )
 
-const WyzwanieBottomSection = () => (
-  <>
-    <MaxWithBgColorContainer bgColor="bg-ada-magicYellow">
-      <div className="px-4 py-14 lg:py-20">
-        <div
-          id={OFFER_SECTION_ID}
-          className="mx-auto w-full max-w-[340px] rounded-[24px] bg-[#f7f4ef] px-6 py-8 text-black shadow-[0_18px_36px_rgba(0,0,0,0.22)] lg:w-[30%] lg:max-w-none lg:px-7 lg:py-8"
-        >
-          <p className="text-[16px] leading-none">{wyzwanieOfferBox.eyebrow}</p>
-          <h2 className="mt-4 text-[36px] lg:text-[42px] font-anton uppercase leading-[110%] whitespace-pre-line">
-            {wyzwanieOfferBox.title}
-          </h2>
+const WyzwanieBottomSection = () => {
+  const { isOtoActive } = useOtoTimer()
+  const currentPrice = isOtoActive ? OTO_PRICE : REGULAR_PRICE
+  const currentUrl = isOtoActive ? OTO_URL : REGULAR_URL
+  const ctaLabel = isOtoActive ? "KUPUJĘ ZA 67 ZŁ" : "KUPUJĘ DOSTĘP"
 
-          <div className="mt-8">
-            <p className="text-[16px] leading-none">
-              {wyzwanieOfferBox.priceLabel}
-            </p>
-            <div className="mt-2 flex items-center gap-3">
-              <p className="text-adaSubtitleThird font-anton uppercase leading-none lg:text-[44px]">
-                {wyzwanieOfferBox.price}
+  return (
+    <>
+      <MaxWithBgColorContainer bgColor="bg-ada-magicYellow">
+        <div className="px-4 py-14 lg:py-20">
+          <div
+            id={OFFER_SECTION_ID}
+            className="mx-auto w-full max-w-[340px] rounded-[24px] bg-[#f7f4ef] px-6 py-8 text-black shadow-[0_18px_36px_rgba(0,0,0,0.22)] lg:w-[30%] lg:max-w-none lg:px-7 lg:py-8"
+          >
+            <p className="text-[16px] leading-none">{wyzwanieOfferBox.eyebrow}</p>
+            <h2 className="mt-4 text-[36px] lg:text-[42px] font-anton uppercase leading-[110%] whitespace-pre-line">
+              {wyzwanieOfferBox.title}
+            </h2>
+
+            <div className="mt-8">
+              <p className="text-[16px] leading-none">
+                {wyzwanieOfferBox.priceLabel}
               </p>
-              <p className="text-[24px] lg:text-[32px] font-anton uppercase leading-none text-gray-400 line-through">
-                {wyzwanieOfferBox.oldPrice}
-              </p>
+              <div className="mt-2 flex items-center gap-3">
+                <p className={`font-anton uppercase leading-none ${isOtoActive ? "text-[48px] lg:text-[56px] text-ada-pink7" : "text-adaSubtitleThird lg:text-[44px]"}`}>
+                  {currentPrice}
+                </p>
+                {isOtoActive && (
+                  <p className="text-[24px] lg:text-[32px] font-anton uppercase leading-none text-gray-400 line-through">
+                    {OTO_OLD_PRICE}
+                  </p>
+                )}
+              </div>
+              {isOtoActive && (
+                <p className="mt-2 text-[14px] font-semibold text-ada-pink7">
+                  Oferta ograniczona czasowo - tylko przez 30 minut!
+                </p>
+              )}
+            </div>
+
+            <Button
+              type="button"
+              variant={isOtoActive ? "pink" : "offer"}
+              url={currentUrl}
+              text={
+                <span className="font-montserrat font-extrabold uppercase">
+                  {ctaLabel}
+                </span>
+              }
+              textSize="text-[22px] lg:text-[26px]"
+              btnStyle="mt-8 w-[85%] mx-auto px-3 py-5 cursor-pointer block text-center"
+            />
+
+            <div className="mt-8 space-y-6">
+              {wyzwanieOfferBox.benefits.map((benefit) => (
+                <div key={benefit.title} className="flex gap-3">
+                  <span className="mt-[2px] text-[18px] leading-none">
+                    {benefit.icon}
+                  </span>
+                  <p className="text-[15px] leading-[120%] lg:text-[14px]">
+                    <span className="block font-bold">{benefit.title}</span>
+                    <span className="block font-normal">
+                      {benefit.description}
+                    </span>
+                  </p>
+                </div>
+              ))}
             </div>
           </div>
-
-          <Button
-            type="button"
-            variant="offer"
-            url={WYZWANIE_CHECKOUT_URL}
-            text={
-              <span className="font-montserrat font-extrabold uppercase">
-                {wyzwanieOfferBox.ctaLabel}
-              </span>
-            }
-            textSize="text-[22px] lg:text-[26px]"
-            btnStyle="mt-8 w-[85%] mx-auto px-3 py-5 cursor-pointer block text-center"
-          />
-
-          <div className="mt-8 space-y-6">
-            {wyzwanieOfferBox.benefits.map((benefit) => (
-              <div key={benefit.title} className="flex gap-3">
-                <span className="mt-[2px] text-[18px] leading-none">
-                  {benefit.icon}
-                </span>
-                <p className="text-[15px] leading-[120%] lg:text-[14px]">
-                  <span className="block font-bold">{benefit.title}</span>
-                  <span className="block font-normal">
-                    {benefit.description}
-                  </span>
-                </p>
-              </div>
-            ))}
-          </div>
         </div>
-      </div>
-    </MaxWithBgColorContainer>
+      </MaxWithBgColorContainer>
 
-    <WyzwanieTestimonials />
-    <WyzwanieCTA />
+      <WyzwanieTestimonials />
+      <WyzwanieCTA />
 
-    <MaxWithBgColorContainer bgColor="bg-ada-magicPink3">
-      <WyzwanieFaq />
-    </MaxWithBgColorContainer>
+      <MaxWithBgColorContainer bgColor="bg-ada-magicPink3">
+        <WyzwanieFaq />
+      </MaxWithBgColorContainer>
 
-    <WyzwanieStartSection />
-  </>
-)
+      <WyzwanieStartSection />
+    </>
+  )
+}
 
 const WyzwaniePage = () => {
   return (
@@ -801,6 +822,7 @@ const WyzwaniePage = () => {
           heroFigure={wyzwanieHeroFigure}
           heroWrapperClassName="lg:right-8 lg:max-w-[800px] xl:right-4 xl:max-w-[950px]"
           heroOverlay={<></>}
+          centerLastRowBenefits
         />
       </div>
     </>


### PR DESCRIPTION
- Add 30-minute OTO timer with localStorage persistence
- Update countdown header to show OTO price and hide after 30 mins
- Make days section fonts match header style (font-normal)
- Center last two tiles in benefits grid
- Add dynamic pricing that switches after OTO expires
- Add pink button variant for OTO period

https://claude.ai/code/session_01NzAJ7WGSL24BUyJxPnMWR6