### PR TITLE
Update wyzwanie countdown button to scroll to offer section

### DIFF
--- a/src/components/WyzwanieStickyCountdown/index.tsx
+++ b/src/components/WyzwanieStickyCountdown/index.tsx
@@ -1,10 +1,20 @@
 import React from "react"
-import { useOtoTimer, OTO_URL } from "hooks/useOtoTimer"
+import { useOtoTimer } from "hooks/useOtoTimer"
+
+const OFFER_SECTION_ID = "oferta"
 
 const WyzwanieStickyCountdown = () => {
   const { isOtoActive, timeLeft } = useOtoTimer()
 
   const padNumber = (num: number) => num.toString().padStart(2, "0")
+
+  const handleScrollToOffer = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+    const element = document.getElementById(OFFER_SECTION_ID)
+    if (element) {
+      element.scrollIntoView({ behavior: "smooth" })
+    }
+  }
 
   if (!isOtoActive) {
     return null
@@ -27,12 +37,12 @@ const WyzwanieStickyCountdown = () => {
             <span className="text-[10px] md:text-xs uppercase">sek</span>
           </div>
         </div>
-        <a
-          href={OTO_URL}
+        <button
+          onClick={handleScrollToOffer}
           className="bg-ada-pink7 text-white font-anton uppercase text-sm md:text-lg px-4 md:px-6 py-1 md:py-2 rounded-full shadow-md hover:brightness-95 transition-all"
         >
-          DOŁĄCZAM W NIŻSZEJ CENIE
-        </a>
+          DOŁĄCZAM ZA 67 ZŁ
+        </button>
       </div>
     </div>
   )

--- a/src/pages/wyzwanie.tsx
+++ b/src/pages/wyzwanie.tsx
@@ -800,10 +800,12 @@ const WyzwanieBottomSection = () => {
 }
 
 const WyzwaniePage = () => {
+  const { isOtoActive } = useOtoTimer()
+
   return (
     <>
       <WyzwanieStickyCountdown />
-      <div className="pt-12">
+      <div className={isOtoActive ? "pt-12" : ""}>
         <TrainingLandingPage
           heroBgColor={wyzwanieHeroBgColor}
           afterHeroSection={wyzwanieAfterHeroSection}


### PR DESCRIPTION
- Change countdown bar button from external link to smooth scroll to #oferta section
- Update button text from "DOŁĄCZAM W NIŻSZEJ CENIE" to "DOŁĄCZAM ZA 67 ZŁ"
- Make top padding conditional on OTO active state - when countdown disappears, yellow hero expands to fill the space

https://claude.ai/code/session_01GxTfoCFzuXuJDR4idvbtuT