### PR TITLE
Enlarge ADVANTAGE+ mockup on homepage

### DIFF
--- a/src/components/HomePageList/index.tsx
+++ b/src/components/HomePageList/index.tsx
@@ -156,8 +156,8 @@ const HomePageList = () => {
               src={"../../images/advantage-mockup.webp"}
               alt="Advantage+ PDF"
               placeholder="blurred"
-              width={400}
-              height={400}
+              width={460}
+              height={460}
               formats={["auto", "webp", "avif"]}
               quality={100}
             />


### PR DESCRIPTION
Increased the mockup image dimensions from 400x400 to 460x460 for better visibility.

https://claude.ai/code/session_012zaPJ6UeCmKZdezPfp8Mq3