### PR TITLE
Fix overlapping team member names in Magic page section

### DIFF
--- a/src/components/MagicBioBanner/PersonBox.tsx
+++ b/src/components/MagicBioBanner/PersonBox.tsx
@@ -34,7 +34,7 @@ const PersonBox = ({
           />
         )}
       </div>
-      <Typography variant="h3" className="mb-2 mt-4 whitespace-nowrap">
+      <Typography variant="h3" className="mb-2 mt-4">
         {name}
       </Typography>
       <p className="text-sm leading-relaxed">{description}</p>


### PR DESCRIPTION
Remove whitespace-nowrap from PersonBox names to allow text wrapping and prevent "Adrianna Promis-Urbas" from overlapping with "Justyna".

https://claude.ai/code/session_01U3VgWQNFhyRC35dug1ac4S