### PR TITLE
Refactor team bios, spacing, and section layout

### DIFF
--- a/src/components/MagicBanner5/index.tsx
+++ b/src/components/MagicBanner5/index.tsx
@@ -86,7 +86,7 @@ const MagicBanner5 = ({ version }: { version: number }) => {
         maxWidth="5xl"
       >
         {version == 1 && (
-          <div className="max-w-4xl mx-auto mb-8 md:mb-20 text-center px-6">
+          <div className="max-w-4xl mx-auto mb-4 md:mb-8 text-center px-6">
             <Typography variant="h2" className="text-ada-black animate-bounce">
               💼
               <br />
@@ -99,7 +99,7 @@ const MagicBanner5 = ({ version }: { version: number }) => {
               Jak <b>Magda</b> uporządkowała chaos reklamowy i zyskała pewność w
               prowadzeniu kampanii?
             </Typography>
-            <div className="my-4 relative">
+            <div className="my-2 relative">
               <Carousel
                 responsive={carouselResponsive}
                 customLeftArrow={<CustomLeftArrow dark />}
@@ -110,7 +110,7 @@ const MagicBanner5 = ({ version }: { version: number }) => {
             </div>
             <Typography
               variant="h3"
-              className="text-ada-black font-medium pt-4"
+              className="text-ada-black font-medium pt-2"
             >
               Przeczytaj, co <b>Magda</b> mówi o <b>MAGIC:</b>
             </Typography>
@@ -121,7 +121,7 @@ const MagicBanner5 = ({ version }: { version: number }) => {
               formats={["auto", "webp", "avif"]}
               quality={75}
               width={800}
-              className="max-w-4xl my-4"
+              className="max-w-4xl my-2"
             />
             <Button
               type="button"
@@ -133,7 +133,7 @@ const MagicBanner5 = ({ version }: { version: number }) => {
           </div>
         )}
         {version == 2 && (
-          <div className="max-w-4xl mx-auto mb-8 md:mb-20 text-center px-6">
+          <div className="max-w-4xl mx-auto mb-4 md:mb-8 text-center px-6">
             <Typography variant="h2" className="text-ada-black animate-bounce">
               👩‍💻
               <br />
@@ -146,7 +146,7 @@ const MagicBanner5 = ({ version }: { version: number }) => {
               Jak <b>Magda</b> uporządkowała chaos reklamowy i zyskała pewność w
               prowadzeniu kampanii?
             </Typography>
-            <div className="my-4 relative">
+            <div className="my-2 relative">
               <Carousel
                 responsive={carouselResponsive}
                 customLeftArrow={<CustomLeftArrow dark />}
@@ -157,7 +157,7 @@ const MagicBanner5 = ({ version }: { version: number }) => {
             </div>
             <Typography
               variant="h3"
-              className="text-ada-black font-medium py-4"
+              className="text-ada-black font-medium py-2"
             >
               Posłuchaj, co <b>Magda</b> mówi o <b>MAGIC:</b>
             </Typography>

--- a/src/components/MagicBelowFold/MainContent.tsx
+++ b/src/components/MagicBelowFold/MainContent.tsx
@@ -15,9 +15,6 @@ const MainContent = () => {
         <MagicBanner version={4} />
       </div>
       <MaxWithBgColorContainer bgColor="bg-ada-pink8">
-        <MagicWhy part={9} />
-      </MaxWithBgColorContainer>
-      <MaxWithBgColorContainer bgColor="bg-ada-white3">
         <MagicDateBanner version={3} />
       </MaxWithBgColorContainer>
       <MaxWithBgColorContainer bgColor="bg-ada-pink8">

--- a/src/components/MagicBelowFold/SocialProof.tsx
+++ b/src/components/MagicBelowFold/SocialProof.tsx
@@ -5,6 +5,7 @@ import MagicBioBanner from "components/MagicBioBanner"
 import MagicCaseStudies from "components/MagicCaseStudies"
 import MagicCommunityOpinions from "components/MagicCommunityOpinions"
 import MagicBanner5 from "components/MagicBanner5"
+import MagicWhy from "components/MagicWhy"
 
 const SocialProof = () => {
   return (
@@ -20,6 +21,9 @@ const SocialProof = () => {
       </MaxWithBgColorContainer>
       <MaxWithBgColorContainer bgColor="bg-ada-white3">
         <MagicCommunityOpinions />
+      </MaxWithBgColorContainer>
+      <MaxWithBgColorContainer bgColor="bg-ada-white3">
+        <MagicWhy part={9} />
       </MaxWithBgColorContainer>
       <MaxWithBgColorContainer bgColor="bg-ada-magicPurple4">
         <MagicBanner5 version={1} />

--- a/src/components/MagicBioBanner/PersonBox.tsx
+++ b/src/components/MagicBioBanner/PersonBox.tsx
@@ -6,7 +6,7 @@ import { CircleImage } from "./circleImages"
 
 type PersonBoxProps = {
   img: string
-  name: string
+  name: string | React.ReactNode
   description: string
   showStamp?: boolean
   textColor?: string
@@ -34,7 +34,7 @@ const PersonBox = ({
           />
         )}
       </div>
-      <Typography variant="h3" className="mb-2 mt-2 whitespace-nowrap">
+      <Typography variant="h3" className="mb-2 mt-2 text-center">
         {name}
       </Typography>
       <p className="text-sm md:text-base leading-relaxed max-w-full">{description}</p>

--- a/src/components/MagicBioBanner/index.tsx
+++ b/src/components/MagicBioBanner/index.tsx
@@ -17,25 +17,49 @@ const bioResponsive = {
 // Static array moved outside component
 const PEOPLE_CONTENT = [
   {
-    name: "Adrianna Promis-Urbas",
+    name: (
+      <>
+        Adrianna
+        <br />
+        Promis-Urbas
+      </>
+    ),
     description:
       "Kreatywna dusza i mózg MAGIC. Specjalizuje się w kampaniach Meta Ads i marketingu zbudowanym na relacjach.",
     img: "ada",
   },
   {
-    name: "Justyna Król",
+    name: (
+      <>
+        Justyna
+        <br />
+        Król
+      </>
+    ),
     description:
       "Socjolożka i zaklinaczka słów. Tworzy teksty reklamowe budujące autentyczne relacje między marką a klientami.",
     img: "justyna",
   },
   {
-    name: "Dorota Woźniak",
+    name: (
+      <>
+        Dorota
+        <br />
+        Woźniak
+      </>
+    ),
     description:
       "Architektka z pasją do projektowania. Zamienia nudne reklamy w przyciągające wzrok kreacje graficzne.",
     img: "dorota",
   },
   {
-    name: "Nicola Kut",
+    name: (
+      <>
+        Nicola
+        <br />
+        Kut
+      </>
+    ),
     description:
       "Analityczka biznesu-to-be, dla której żadne liczby i raporty nie są straszne. Przeprowadza researche, tworzy kampanie i ogarnia kulisy pracy.",
     img: "nicola",
@@ -46,10 +70,10 @@ const PEOPLE_CONTENT = [
 const PeopleResponsive = ({ showStamp = false }: { showStamp?: boolean }) => (
   <>
     {/* Desktop: grid layout */}
-    <div className="hidden md:grid md:grid-cols-2 lg:grid-cols-4 gap-6 pt-8 justify-items-center">
-      {PEOPLE_CONTENT.map((item) => (
+    <div className="hidden md:grid md:grid-cols-2 lg:grid-cols-4 gap-6 pt-8 justify-items-center items-start">
+      {PEOPLE_CONTENT.map((item, index) => (
         <PersonBox
-          key={item.name}
+          key={index}
           name={item.name}
           description={item.description}
           img={item.img}
@@ -67,8 +91,8 @@ const PeopleResponsive = ({ showStamp = false }: { showStamp?: boolean }) => (
         customRightArrow={<CustomRightArrow />}
         ssr={true}
       >
-        {PEOPLE_CONTENT.map((item) => (
-          <div key={item.name} className="px-2">
+        {PEOPLE_CONTENT.map((item, index) => (
+          <div key={index} className="px-2">
             <PersonBox
               name={item.name}
               description={item.description}
@@ -228,10 +252,10 @@ const MagicBioBanner = ({ version }: { version: number }) => {
             </p>
 
             {/* Desktop: grid layout */}
-            <div className="hidden md:grid md:grid-cols-2 lg:grid-cols-4 gap-6 pt-8 justify-items-center">
-              {PEOPLE_CONTENT.map((item) => (
+            <div className="hidden md:grid md:grid-cols-2 lg:grid-cols-4 gap-6 pt-8 justify-items-center items-start">
+              {PEOPLE_CONTENT.map((item, index) => (
                 <PersonBox
-                  key={item.name}
+                  key={index}
                   name={item.name}
                   description={item.description}
                   img={item.img}
@@ -250,8 +274,8 @@ const MagicBioBanner = ({ version }: { version: number }) => {
                 customRightArrow={<CustomRightArrow />}
                 ssr={true}
               >
-                {PEOPLE_CONTENT.map((item) => (
-                  <div key={item.name} className="px-2">
+                {PEOPLE_CONTENT.map((item, index) => (
+                  <div key={index} className="px-2">
                     <PersonBox
                       name={item.name}
                       description={item.description}

--- a/src/components/MagicDateBanner/index.tsx
+++ b/src/components/MagicDateBanner/index.tsx
@@ -64,7 +64,7 @@ const magicTilesContent2 = [
     colors: "bg-ada-pink8 text-ada-purple2",
     title: "Ekskluzywny dostęp",
     description:
-      "Najnowsze autorskie szkolenia i materiały dostępne w tylko w MAGIC. Pssst… wpisz kod KOALA, ale nie mów nikomu.",
+      "Najnowsze autorskie szkolenia i materiały dostępne w tylko w MAGIC. 🦫 Pssst… wpisz kod KAPIBARA, ale nie mów nikomu.",
   },
 ]
 

--- a/src/components/MagicSaleBanner/index.tsx
+++ b/src/components/MagicSaleBanner/index.tsx
@@ -28,9 +28,9 @@ const MagicSaleBanner = ({
               {/* Big heading */}
               <div className="flex items-start gap-3 justify-center lg:justify-start">
                 <h1 className="font-montserrat font-extrabold text-[40px] md:text-[56px] lg:text-[64px] leading-[100%] text-ada-magicOrange2 mb-6">
-                  Marketing Ads Girls
+                  Marketing Ads
                   <br />
-                  Inside Club
+                  Girls Inside Club
                 </h1>
                 <StaticImage
                   src="../../images/star-pink.webp"

--- a/src/components/MagicWhy/index.tsx
+++ b/src/components/MagicWhy/index.tsx
@@ -242,8 +242,7 @@ const MagicWhy = ({ part }: { part: number }) => {
         <div>
           <div className="w-full text-black mb-20">
             <Typography variant="h1" className="mb-8 text-center uppercase">
-              <span className="text-white">MAGIC </span>
-              jest dla...
+              JEŚLI PROWADZISZ MARKETING DLA...
             </Typography>
           </div>
           <div
@@ -259,7 +258,7 @@ const MagicWhy = ({ part }: { part: number }) => {
                     variant="h2"
                     className="mb-8 text-center uppercase  border-b-[3px]  border-ada-magicGrey2 pb-4"
                   >
-                    🧑‍🎓 Przedsiębiorczyń:
+                    SWOJEGO BIZNESU
                   </Typography>
                   <ul className="px-8">
                     <li className="mb-3">
@@ -321,9 +320,9 @@ const MagicWhy = ({ part }: { part: number }) => {
                 <div className="max-w-md bg-ada-white3 pt-8 py-12 border-[3px] border-ada-magicPink4">
                   <Typography
                     variant="h2"
-                    className="mb-8 text-center animate-bounce uppercase  border-b-[3px]  border-ada-magicGrey2 pb-4"
+                    className="mb-8 text-center uppercase  border-b-[3px]  border-ada-magicGrey2 pb-4"
                   >
-                    🧑‍🎓 Marketerek:
+                    DLA KLIENTÓW
                   </Typography>
                   <ul className="px-8">
                     <li className="mb-3">


### PR DESCRIPTION
## Summary
This PR updates the team bio section layout, adjusts spacing throughout the page, refactors the "Why MAGIC" section, and reorganizes component placement in the social proof section.

## Key Changes

**Team Bio Section (MagicBioBanner)**
- Updated team member names to display with line breaks using JSX (`<br />`) for better visual formatting
- Changed key prop from `item.name` to `index` in map functions (2 locations)
- Added `items-start` class to desktop grid for proper alignment
- Updated PersonBox to accept `name` as `string | React.ReactNode` type
- Removed `whitespace-nowrap` and added `text-center` to name typography for centered display

**Spacing Adjustments (MagicBanner5)**
- Reduced bottom margins: `mb-8 md:mb-20` → `mb-4 md:mb-8`
- Reduced carousel spacing: `my-4` → `my-2`
- Reduced heading padding: `pt-4` → `pt-2` and `py-4` → `py-2`
- Reduced image margin: `my-4` → `my-2`

**Why MAGIC Section (MagicWhy)**
- Changed main heading from "MAGIC jest dla..." to "JEŚLI PROWADZISZ MARKETING DLA..."
- Updated section titles: "🧑‍🎓 Przedsiębiorczyń:" → "SWOJEGO BIZNESU"
- Updated section titles: "🧑‍🎓 Marketerek:" → "DLA KLIENTÓW"
- Removed `animate-bounce` class from second section heading

**Component Reorganization (SocialProof & MainContent)**
- Moved `MagicWhy part={9}` from MainContent to SocialProof component
- Changed background color context from `bg-ada-pink8` to `bg-ada-white3` for MagicWhy
- Removed MagicWhy from MainContent entirely

**Other Updates**
- Updated MagicSaleBanner heading: "Marketing Ads Girls Inside Club" → "Marketing Ads Girls Inside Club" (split across lines)
- Updated MagicDateBanner promo code: "KOALA" → "KAPIBARA" with emoji (🦫)

## Implementation Details
- All changes maintain existing component structure and props
- Spacing reductions improve visual hierarchy and reduce excessive whitespace
- Team member name formatting uses React fragments for semantic HTML
- Component reorganization improves content flow in the social proof section

https://claude.ai/code/session_01C83sVY1S7JzWeueWxhjaR3