### PR TITLE
Remove bonus text from magic-special page

### DIFF
--- a/src/pages/magic-special.tsx
+++ b/src/pages/magic-special.tsx
@@ -48,13 +48,6 @@ const MagicSpecialPage = () => {
           column2BgColor="bg-[#F5CEE2]"
           column3BgColor="bg-[#E8F6CD]"
         />
-        <div className="max-w-4xl mx-auto px-4 pb-12 pt-6">
-          <p className="text-lg text-center text-ada-blue">
-            🎁 <strong>Bonus tylko dla Was, uczestniczek wyzwania:</strong> jeżeli
-            dołączysz do MAGIC w ciągu 24h od zakończenia wyzwania - otrzymasz
-            indywidualną analizę lejka sprzedażowego z Nicolą.
-          </p>
-        </div>
       </MaxWithBgColorContainer>
       <div className="bg-magic">
         <MaxWithBgColorContainer bgColor="bg-transparent">


### PR DESCRIPTION
Remove the time-limited bonus offer text in the "Dołącz do MAGIC" section that offered individual sales funnel analysis with Nicola.

Slack thread: https://getboldworkspace.slack.com/archives/CKVBMQHJ5/p1779103516919749?thread_ts=1779103458.178009&cid=CKVBMQHJ5

https://claude.ai/code/session_01KDdTPnhJxbEadT8gpWFuCD