### PR TITLE
Swap headers in magic page marketing section

### DIFF
--- a/src/components/MagicWhy/index.tsx
+++ b/src/components/MagicWhy/index.tsx
@@ -258,7 +258,7 @@ const MagicWhy = ({ part }: { part: number }) => {
                     variant="h2"
                     className="mb-8 text-center uppercase  border-b-[3px]  border-ada-magicGrey2 pb-4"
                   >
-                    KLIENTÓW
+                    🎓 SWOJEGO BIZNESU
                   </Typography>
                   <ul className="px-8">
                     <li className="mb-3">
@@ -322,7 +322,7 @@ const MagicWhy = ({ part }: { part: number }) => {
                     variant="h2"
                     className="mb-8 text-center animate-bounce uppercase  border-b-[3px]  border-ada-magicGrey2 pb-4"
                   >
-                    🧑‍🎓 SWOJEGO BIZNESU
+                    🎓 KLIENTÓW
                   </Typography>
                   <ul className="px-8">
                     <li className="mb-3">


### PR DESCRIPTION
Fix section headers in the "JEŚLI PROWADZISZ MARKETING DLA..." area:
- First box (for people new to ads) now displays "🎓 SWOJEGO BIZNESU"
- Second box (for marketers) now displays "🎓 KLIENTÓW"

https://claude.ai/code/session_01DYVo9yNLcAoMjCv7WQfzXc