### PR TITLE
Fix magic-wyzwanie: heading, Nicola pop-up, opinions button, FAQ emoji

### DIFF
--- a/src/components/MagicCommunityOpinions/index.tsx
+++ b/src/components/MagicCommunityOpinions/index.tsx
@@ -74,9 +74,9 @@ const MagicCommunityOpinions = ({
             >
               <Button
                 type="button"
-                text="Dołączam"
-                variant="pink"
-                btnStyle="px-8 py-4"
+                text={<span className="!font-extrabold">Dołączam</span>}
+                textSize="text-xs md:text-adaBase uppercase text-black"
+                btnStyle="bg-ada-pink8 tracking-wide p-3 hover:opacity-90 rounded-full min-w-[130px] h-[58px] shadow-xl"
               />
             </a>
           </div>

--- a/src/components/MagicSaleBanner/index.tsx
+++ b/src/components/MagicSaleBanner/index.tsx
@@ -3,6 +3,7 @@ import { Button } from "helpers/Button"
 import TypingAnimation from "helpers/TypingAnimation"
 import TypingWordSwitch from "helpers/TypingWordSwitch"
 import React from "react"
+import { NicolaCallPopup } from "../NicolaCallPopup"
 import Section from "../shared/Section"
 import StarBadge from "../shared/StarBadge"
 
@@ -388,26 +389,7 @@ const MagicSaleBanner = ({
             </div>
           </div>
 
-          {/* CTA: bezpłatna rozmowa z Nicolą */}
-          <div className="mt-12 flex flex-col items-center text-center">
-            <p className="text-adaSubtitle text-black max-w-[720px]">
-              Nie wiesz, czy MAGIC jest dla Ciebie? Umów{" "}
-              <b>bezpłatną 30-minutową rozmowę z Nicolą</b>
-            </p>
-            <a
-              href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ2R36p86iZGPSsdhYrFdXIzDLsNY1t1QDgYSXS4aHyeqhQTgNOzE_gqZTnzjq0eaNVYtOMgNwpS"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="mt-6"
-            >
-              <Button
-                type="button"
-                text={<span>umawiam się na rozmowę</span>}
-                textSize="text-base md:text-adaSubtitleSecondary uppercase !font-extrabold text-black"
-                btnStyle="bg-ada-magicPink4 tracking-wide p-3 hover:opacity-90 rounded-full min-w-[180px] h-[56px] shadow-xl"
-              />
-            </a>
-          </div>
+          <NicolaCallPopup />
         </Section>
       )}
       {version == 6 && (

--- a/src/components/MagicWhy/index.tsx
+++ b/src/components/MagicWhy/index.tsx
@@ -445,10 +445,14 @@ const MagicWhy = ({ part }: { part: number }) => {
             formats={["auto", "webp", "avif"]}
             quality={75}
           />
-          <p className="mt-6 max-w-2xl text-center text-ada-black">
-            Twój MAGIC Plan podpowie, które z tych spotkań są dla Ciebie
-            najważniejsze w pierwszym miesiącu.
-          </p>
+          <Typography
+            variant="h2"
+            className="mt-6 max-w-3xl text-center font-bold text-ada-black"
+          >
+            Twój <span className="text-ada-pink7">MAGIC Plan</span> podpowie,
+            które z tych spotkań są dla Ciebie najważniejsze w pierwszym
+            miesiącu.
+          </Typography>
         </div>
       )}
       {part == 13 && (

--- a/src/components/MasterclassFAQ/index.tsx
+++ b/src/components/MasterclassFAQ/index.tsx
@@ -521,7 +521,7 @@ const MasterclassFAQ = ({ version }: MasterclassFAQProps) => {
       ),
     },
     {
-      question: "🎯 Jak wygląda MAGIC Plan na start?",
+      question: "🚀 Jak wygląda MAGIC Plan na start?",
       answer: (
         <>
           Po dołączeniu wypełniasz krótki formularz (10 minut) i umawiasz

--- a/src/components/NicolaCallPopup/index.tsx
+++ b/src/components/NicolaCallPopup/index.tsx
@@ -1,0 +1,67 @@
+import { Button } from "helpers/Button"
+import React, { useEffect, useRef, useState } from "react"
+
+const NICOLA_CALENDAR_URL =
+  "https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ2R36p86iZGPSsdhYrFdXIzDLsNY1t1QDgYSXS4aHyeqhQTgNOzE_gqZTnzjq0eaNVYtOMgNwpS"
+
+export const NicolaCallPopup = () => {
+  const sentinelRef = useRef<HTMLDivElement>(null)
+  const [visible, setVisible] = useState(false)
+  const [dismissed, setDismissed] = useState(false)
+
+  useEffect(() => {
+    const el = sentinelRef.current
+    if (!el || typeof IntersectionObserver === "undefined") return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setVisible(true)
+          observer.disconnect()
+        }
+      },
+      { threshold: 0.2 }
+    )
+
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  return (
+    <>
+      {/* Sentinel: marks the end of the section. When it scrolls into view
+          (reader is finishing the section) the pop-up appears. */}
+      <div ref={sentinelRef} aria-hidden className="h-px w-full" />
+
+      {visible && !dismissed && (
+        <div className="fixed inset-x-4 bottom-4 z-[60] mx-auto max-w-md rounded-3xl bg-ada-magicPink4 p-6 pt-8 text-center text-black shadow-2xl md:inset-x-auto md:right-6 md:bottom-6">
+          <button
+            type="button"
+            onClick={() => setDismissed(true)}
+            aria-label="Zamknij"
+            className="absolute right-3 top-3 flex h-8 w-8 items-center justify-center rounded-full text-2xl leading-none text-black transition hover:opacity-60"
+          >
+            &times;
+          </button>
+          <p className="text-adaSubtitle text-black">
+            Nie wiesz, czy MAGIC jest dla Ciebie? Umów{" "}
+            <b>bezpłatną 30-minutową rozmowę z Nicolą</b>
+          </p>
+          <a
+            href={NICOLA_CALENDAR_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-5 inline-block"
+          >
+            <Button
+              type="button"
+              text={<span>umawiam się na rozmowę</span>}
+              textSize="text-base uppercase !font-extrabold text-white"
+              btnStyle="bg-ada-black tracking-wide p-3 hover:opacity-90 rounded-full min-w-[180px] h-[56px] shadow-xl"
+            />
+          </a>
+        </div>
+      )}
+    </>
+  )
+}


### PR DESCRIPTION
- MagicWhy part 12: turn "Twój MAGIC Plan podpowie..." into a visible h2 heading
- MagicSaleBanner v2: replace inline "rozmowa z Nicolą" CTA with a scroll-triggered pink pop-up (NicolaCallPopup) linking to Nicola's calendar
- MagicCommunityOpinions: restyle button to match the case-study (MagicBanner5) button
- MasterclassFAQ: change duplicate emoji on "Jak wygląda MAGIC Plan na start?" from target to rocket


Claude-Session: https://claude.ai/code/session_01JDdaz5BWGPmQFxsnei5vJZ