### PR TITLE
Aktualizacja strony magic-wyzwanie: nagłówek, pop-up z Nicolą, przycisk opinii, emoji FAQ

### DIFF
--- a/src/components/MagicCommunityOpinions/index.tsx
+++ b/src/components/MagicCommunityOpinions/index.tsx
@@ -74,9 +74,9 @@ const MagicCommunityOpinions = ({
             >
               <Button
                 type="button"
-                text="Dołączam"
-                variant="pink"
-                btnStyle="px-8 py-4"
+                text={<span>Dołączam</span>}
+                textSize="font-montserrat !font-extrabold text-[18px] md:text-[24px] leading-[100%] uppercase text-black"
+                btnStyle="bg-ada-pink8 hover:opacity-90 hover:shadow-xl rounded-full py-4 px-8 md:py-6 md:px-12"
               />
             </a>
           </div>

--- a/src/components/MagicNicolaPopup/index.tsx
+++ b/src/components/MagicNicolaPopup/index.tsx
@@ -1,0 +1,77 @@
+import { Button } from "helpers/Button"
+import React, { useEffect, useRef, useState } from "react"
+
+const NICOLA_CALENDAR_URL =
+  "https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ2R36p86iZGPSsdhYrFdXIzDLsNY1t1QDgYSXS4aHyeqhQTgNOzE_gqZTnzjq0eaNVYtOMgNwpS"
+
+const MagicNicolaPopup = () => {
+  const sentinelRef = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+  const [hasShown, setHasShown] = useState(false)
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current
+    if (!sentinel || hasShown) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setIsVisible(true)
+            setHasShown(true)
+            observer.disconnect()
+          }
+        })
+      },
+      { threshold: 0.1 }
+    )
+
+    observer.observe(sentinel)
+    return () => observer.disconnect()
+  }, [hasShown])
+
+  return (
+    <>
+      {/* Sentinel: marks the end of the section. The pop-up fires once the
+          reader scrolls far enough to reach it (i.e. finishes the section). */}
+      <div ref={sentinelRef} aria-hidden="true" className="h-px w-full" />
+
+      {isVisible && (
+        <div className="fixed inset-x-4 bottom-4 z-50 md:inset-x-auto md:right-6 md:max-w-sm">
+          <div className="relative rounded-2xl bg-ada-magicPink4 p-6 text-black shadow-2xl">
+            <button
+              type="button"
+              aria-label="Zamknij"
+              onClick={() => setIsVisible(false)}
+              className="absolute right-3 top-2 text-3xl leading-none text-black transition hover:opacity-70"
+            >
+              &times;
+            </button>
+            <p className="pr-6 text-lg font-bold text-black">
+              Nie wiesz, czy MAGIC jest dla Ciebie?
+            </p>
+            <p className="mt-2 text-black">
+              Umów <b>bezpłatną 30-minutową rozmowę z Nicolą</b>.
+            </p>
+            <a
+              href={NICOLA_CALENDAR_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-4 inline-block"
+              onClick={() => setIsVisible(false)}
+            >
+              <Button
+                type="button"
+                text={<span>umawiam się na rozmowę</span>}
+                textSize="text-base uppercase !font-extrabold text-black"
+                btnStyle="bg-white tracking-wide p-3 hover:opacity-90 rounded-full min-w-[180px] h-[56px] shadow-xl"
+              />
+            </a>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}
+
+export default MagicNicolaPopup

--- a/src/components/MagicSaleBanner/index.tsx
+++ b/src/components/MagicSaleBanner/index.tsx
@@ -5,6 +5,7 @@ import TypingWordSwitch from "helpers/TypingWordSwitch"
 import React from "react"
 import Section from "../shared/Section"
 import StarBadge from "../shared/StarBadge"
+import MagicNicolaPopup from "../MagicNicolaPopup"
 
 const MagicSaleBanner = ({
   version,
@@ -388,26 +389,7 @@ const MagicSaleBanner = ({
             </div>
           </div>
 
-          {/* CTA: bezpłatna rozmowa z Nicolą */}
-          <div className="mt-12 flex flex-col items-center text-center">
-            <p className="text-adaSubtitle text-black max-w-[720px]">
-              Nie wiesz, czy MAGIC jest dla Ciebie? Umów{" "}
-              <b>bezpłatną 30-minutową rozmowę z Nicolą</b>
-            </p>
-            <a
-              href="https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ2R36p86iZGPSsdhYrFdXIzDLsNY1t1QDgYSXS4aHyeqhQTgNOzE_gqZTnzjq0eaNVYtOMgNwpS"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="mt-6"
-            >
-              <Button
-                type="button"
-                text={<span>umawiam się na rozmowę</span>}
-                textSize="text-base md:text-adaSubtitleSecondary uppercase !font-extrabold text-black"
-                btnStyle="bg-ada-magicPink4 tracking-wide p-3 hover:opacity-90 rounded-full min-w-[180px] h-[56px] shadow-xl"
-              />
-            </a>
-          </div>
+          <MagicNicolaPopup />
         </Section>
       )}
       {version == 6 && (

--- a/src/components/MagicWhy/index.tsx
+++ b/src/components/MagicWhy/index.tsx
@@ -445,10 +445,13 @@ const MagicWhy = ({ part }: { part: number }) => {
             formats={["auto", "webp", "avif"]}
             quality={75}
           />
-          <p className="mt-6 max-w-2xl text-center text-ada-black">
+          <Typography
+            variant="h2"
+            className="mt-6 max-w-3xl text-center text-ada-black font-bold"
+          >
             Twój MAGIC Plan podpowie, które z tych spotkań są dla Ciebie
             najważniejsze w pierwszym miesiącu.
-          </p>
+          </Typography>
         </div>
       )}
       {part == 13 && (

--- a/src/components/MasterclassFAQ/index.tsx
+++ b/src/components/MasterclassFAQ/index.tsx
@@ -521,7 +521,7 @@ const MasterclassFAQ = ({ version }: MasterclassFAQProps) => {
       ),
     },
     {
-      question: "🎯 Jak wygląda MAGIC Plan na start?",
+      question: "🚀 Jak wygląda MAGIC Plan na start?",
       answer: (
         <>
           Po dołączeniu wypełniasz krótki formularz (10 minut) i umawiasz


### PR DESCRIPTION
## Zmiany na stronie `/magic-wyzwanie`

Wprowadza cztery poprawki zgłoszone na Slacku:

1. **Sekcja „przykładowy miesiąc w MAGIC”** — tekst *„Twój MAGIC Plan podpowie, które z tych spotkań są dla Ciebie najważniejsze w pierwszym miesiącu.”* renderuje się teraz jako widoczny nagłówek (`Typography variant="h2"`, pogrubiony, wyśrodkowany), pasujący do stylu nagłówka tej sekcji.
2. **Bezpłatna rozmowa z Nicolą** — inline'owy tekst *„Nie wiesz, czy MAGIC jest dla Ciebie?…”* wraz z przyciskiem *„umawiam się na rozmowę”* został zamieniony na wyskakujący pop-up. Pop-up pojawia się dopiero, gdy czytelnik dochodzi do końca sekcji z pakietami (trigger oparty na `IntersectionObserver`), jest różowy z czarnym napisem, można go zamknąć, a przycisk kieruje do kalendarza Nicoli. Nowy komponent: `src/components/MagicNicolaPopup`.
3. **Sekcja z opiniami** — przycisk *„Dołączam”* został przestylowany, aby wyglądał jak przycisk w sekcji case study / hero (montserrat, extrabold, `bg-ada-pink8`, zaokrąglony). Link do koszyka pozostał bez zmian.
4. **FAQ** — emoji przy pytaniu *„Jak wygląda MAGIC Plan na start?”* zmienione z 🎯 na 🚀, aby żadne emoji się nie powtarzało (teraz: 🔍 💎 🚀 🎯 📚 ⏰ 🦫).

### Zmienione pliki
- `src/components/MagicWhy/index.tsx`
- `src/components/MagicNicolaPopup/index.tsx` (nowy)
- `src/components/MagicSaleBanner/index.tsx`
- `src/components/MagicCommunityOpinions/index.tsx`
- `src/components/MasterclassFAQ/index.tsx`

---
Wątek na Slacku: https://getboldworkspace.slack.com/archives/CKVBMQHJ5/p1783527032209669?thread_ts=1783524648.237579&cid=CKVBMQHJ5

---
_Generated by [Claude Code](https://claude.ai/code/session_01739z1nhvX5Bxyupzbc3Jse)_