### PR TITLE
Swap magic-kolektyw calendar to new booking link

### DIFF
--- a/src/components/MagicBanner3/BannerBox3.tsx
+++ b/src/components/MagicBanner3/BannerBox3.tsx
@@ -44,7 +44,7 @@ const BannerBox3 = ({
               </span>
             </span>
           }
-          url="https://calendar.app.google/UwK6B7FAiut4VnZB7"
+          url="https://calendar.app.google/svhytZTJ93aiMJ6BA"
           textSize="text-base md:text-lg"
           btnStyle="bg-ada-white2
                 tracking-wide h-auto py-4

--- a/src/components/MagicCollectiveBanner/index.tsx
+++ b/src/components/MagicCollectiveBanner/index.tsx
@@ -349,7 +349,7 @@ const MagicCollectiveBanner = ({ version }: { version: number }) => {
               className="max-w-[800px] mx-auto bg-white p-2 md:p-3"
             >
               <iframe
-                src="https://calendar.google.com/calendar/appointments/schedules/AcZssZ0zcRiXUr4-wUE8kWad3VOUdAuWCYFT8Sx9MdThd_nrVecbrxdhp52S2M_iVeoZHU40tpiiuoEn?gv=true"
+                src="https://calendar.google.com/calendar/appointments/schedules/AcZssZ2R36p86iZGPSsdhYrFdXIzDLsNY1t1QDgYSXS4aHyeqhQTgNOzE_gqZTnzjq0eaNVYtOMgNwpS?gv=true"
                 style={{ border: 0 }}
                 width="100%"
                 height="600"


### PR DESCRIPTION
Update the booking CTA button (MagicBanner3/BannerBox3) and the embedded scheduling iframe (MagicCollectiveBanner v7) on the magic-kolektyw page to point to the new Google Calendar (calendar.app.google/svhytZTJ93aiMJ6BA, schedule AcZssZ2R36p86...).


Claude-Session: https://claude.ai/code/session_01JqexrfVzZHhnEmGyNWnCMH